### PR TITLE
APIMF-1777: added hashcode() to Field and added recursion control in RdfModelParser

### DIFF
--- a/shared/src/main/scala/amf/core/metamodel/Field.scala
+++ b/shared/src/main/scala/amf/core/metamodel/Field.scala
@@ -16,4 +16,5 @@ case class Field(`type`: Type, value: ValueType, doc: ModelDoc = ModelDoc(), jso
       case _           => false
     }
 
+  override def hashCode(): Int = value.iri().hashCode
 }


### PR DESCRIPTION
This PR is related to:
- https://github.com/mulesoft/amf-aml/pull/30
- https://github.com/mulesoft/amf/pull/217

The changes made here are to fix the flaky SOF in AMF tests. The SOF has been resolved but the flakyness hasn't.

Some improvements that can be made to the RdfModelParser are:

- [ ] Have an extensive Rdf parsing suite in amf-core project (there aren't many rdf unit tests in amf-client and there are no tests in amf-core).
- [ ] Propagate recursion control to all parsing methods. Currently there is only recursion control when a property array is parsed. Other recursion situations should be identified to properly propagate recursion control. At first glance a good way to do this would be to separate the different subparsings in the Parser and wrap them with the RecursionControl logic to DRY the code.
- [ ] Can recursion control logic change over time? Currently it is added as an instance field but it could be received in the parser constructor. This could be identified with checkbox 2.
- [ ] Properly identify the need for amf-aml PR. If said PR is omitted the field duplication still exists even if using the _distinct_ list of fields.

Until these issues are discussed this PR will remain as draft.