### PR TITLE
Revert "APIMF-2114: resolving Root location to parser context rootContextDocument as the Content url can be changed according to the ResourceLoader use. Root location should be invariant to this"

### DIFF
--- a/shared/src/main/scala/amf/core/AMFCompiler.scala
+++ b/shared/src/main/scala/amf/core/AMFCompiler.scala
@@ -145,8 +145,8 @@ class CompilerContextBuilder(url: String,
 
   private def buildParserContext(fc: Context) = givenContent match {
     case Some(given) if given.rootContextDocument.equals(fc.current) => given
-    case Some(given)                                                 => given.forLocation(platform.resolvePath(fc.current))
-    case None                                                        => ParserContext(platform.resolvePath(fc.current), eh = eh)
+    case Some(given)                                                 => given.forLocation(fc.current)
+    case None                                                        => ParserContext(fc.current, eh = eh)
   }
 
   def build()(implicit executionContext: ExecutionContext): CompilerContext = {
@@ -243,7 +243,7 @@ class AMFCompiler(compilerContext: CompilerContext,
           case (d, p) =>
             p.onSyntaxParsed(compilerContext.path, d)
         }
-        Right(Root(doc, compilerContext.parserContext.rootContextDocument, effective, Seq(), referenceKind, content.stream.toString))
+        Right(Root(doc, content.url, effective, Seq(), referenceKind, content.stream.toString))
       case None =>
         Left(content)
     }


### PR DESCRIPTION
Reverts mulesoft/amf-core#42