### PR TITLE
Fixing problems in the declaration of the JS interface

### DIFF
--- a/shared/src/main/scala/amf/client/model/document/BaseUnit.scala
+++ b/shared/src/main/scala/amf/client/model/document/BaseUnit.scala
@@ -1,8 +1,8 @@
 package amf.client.model.document
 
 import amf.client.convert.CoreClientConverters._
-import amf.client.model.{AmfObjectWrapper, StrField}
 import amf.client.model.domain.DomainElement
+import amf.client.model.{AmfObjectWrapper, StrField}
 import amf.client.render.RenderOptions
 import amf.core.model.document.{BaseUnit => InternalBaseUnit}
 import amf.core.rdf.RdfModel

--- a/shared/src/main/scala/amf/client/model/document/Document.scala
+++ b/shared/src/main/scala/amf/client/model/document/Document.scala
@@ -10,6 +10,7 @@ import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
   * Document model class.
   */
 @JSExportAll
+@JSExportTopLevel("model.document.Document")
 class Document(private[amf] val _internal: InternalDocument) extends BaseUnit with EncodesModel with DeclaresModel {
 
   @JSExportTopLevel("model.document.Document")

--- a/shared/src/main/scala/amf/client/model/document/Fragment.scala
+++ b/shared/src/main/scala/amf/client/model/document/Fragment.scala
@@ -8,17 +8,18 @@ import amf.core.model.document.{Fragment => InternalFragment, PayloadFragment =>
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 
 @JSExportAll
+@JSExportTopLevel("model.document.Fragment")
 class Fragment(private[amf] val _internal: InternalFragment) extends BaseUnit with EncodesModel
 
 @JSExportAll
 case class PayloadFragment(override private[amf] val _internal: InternalPayloadFragment) extends Fragment(_internal) {
-  @JSExportTopLevel("model.domain.PayloadFragment")
+  @JSExportTopLevel("model.document.PayloadFragment")
   def this(scalar: ScalarNode, mediaType: String) = this(InternalPayloadFragment(scalar._internal, mediaType))
 
-  @JSExportTopLevel("model.domain.PayloadFragment")
+  @JSExportTopLevel("model.document.PayloadFragment")
   def this(obj: ObjectNode, mediaType: String) = this(InternalPayloadFragment(obj._internal, mediaType))
 
-  @JSExportTopLevel("model.domain.PayloadFragment")
+  @JSExportTopLevel("model.document.PayloadFragment")
   def this(arr: ArrayNode, mediaType: String) = this(InternalPayloadFragment(arr._internal, mediaType))
 
   def mediaType: StrField = _internal.mediaType


### PR DESCRIPTION
Some JS wrapper classes were not exported at the top level (document) or exported in the domain instead of document namespace (PayloadFragment).

This was causing null values when trying to get the prototype function in JS/TS.

This should not be a breaking change, but a fix, since the previous code was failing.