### PR TITLE
Declaring missing JS interface

### DIFF
--- a/js/src/main/scala/amf/client/convert/CoreBaseClientConverter.scala
+++ b/js/src/main/scala/amf/client/convert/CoreBaseClientConverter.scala
@@ -84,4 +84,14 @@ trait CoreBaseClientConverter extends CoreBaseConverter {
 
 //  override protected def toClientOptionWithEC[E](from: Option[E])(
 //      implicit executionContext: ExecutionContext): ClientOption[E] = from.orUndefined
+
+
+  override protected def asInternalMap[Client, Internal](from: ClientMap[Client], m: ClientInternalMatcher[Client, Internal]): Map[String, Internal] = {
+
+    from.toMap.foldLeft(Map[String,Internal]()) { case (acc, (e,i)) =>
+      acc + (e -> m.asInternal(i))
+    }
+
+  }
+
 }

--- a/jvm/src/main/scala/amf/client/convert/CoreBaseClientConverter.scala
+++ b/jvm/src/main/scala/amf/client/convert/CoreBaseClientConverter.scala
@@ -89,4 +89,11 @@ trait CoreBaseClientConverter extends CoreBaseConverter {
 
 //  override protected def toClientOptionWithEC[E](from: Option[E])(
 //      implicit executionContext: ExecutionContext): ClientOption[E] = from.asJava
+
+  override protected def asInternalMap[Client, Internal](from: ClientMap[Client], m: ClientInternalMatcher[Client, Internal]): Map[String, Internal] = {
+    from.asScala.toMap.foldLeft(Map[String,Internal]()) { case (acc, (e,i)) =>
+      acc + (e -> m.asInternal(i))
+    }
+  }
+
 }

--- a/shared/src/main/scala/amf/client/convert/CoreBaseConverter.scala
+++ b/shared/src/main/scala/amf/client/convert/CoreBaseConverter.scala
@@ -194,7 +194,13 @@ trait CollectionConverter {
     def toScala: Option[Client] = toScalaOption(from)
   }
 
-//  implicit class ClientOptionOpsWithEC[Client](from: ClientOption[Client])(
+  implicit class ClientMapOps[Internal, Client](from: ClientMap[Client])(
+    implicit m: ClientInternalMatcher[Client, Internal]
+  ) {
+    def asInternal: Map[String,Internal] = asInternalMap(from, m)
+  }
+
+  //  implicit class ClientOptionOpsWithEC[Client](from: ClientOption[Client])(
 //      implicit executionContext: ExecutionContext) {
 //    def toScala: Option[Client] = toScalaOptionWithEC(from)
 //  }
@@ -262,6 +268,11 @@ trait CollectionConverter {
   protected def asInternalSeqWithEC[Client, Internal](
       from: ClientList[Client],
       m: ClientInternalMatcherWithEC[Client, Internal])(implicit executionContext: ExecutionContext): Seq[Internal]
+
+  protected def asInternalMap[Client, Internal](
+      from: ClientMap[Client],
+       m: ClientInternalMatcher[Client, Internal]): Map[String, Internal]
+
 }
 
 trait FieldConverter extends CollectionConverter {


### PR DESCRIPTION
Adding missing methods to conver maps as part of the PR to expose more of the JS interface