### PR TITLE
First version of external link

### DIFF
--- a/shared/src/main/scala/amf/client/model/domain/DomainElement.scala
+++ b/shared/src/main/scala/amf/client/model/domain/DomainElement.scala
@@ -1,7 +1,7 @@
 package amf.client.model.domain
 
 import amf.client.convert.CoreClientConverters._
-import amf.client.model.AmfObjectWrapper
+import amf.client.model.{AmfObjectWrapper, BoolField}
 import amf.core.model.domain.{DomainElement => InternalDomainElement, Graph => InternalGraph}
 import amf.core.parser.Range
 import amf.core.unsafe.PlatformSecrets
@@ -33,6 +33,12 @@ trait DomainElement extends AmfObjectWrapper with PlatformSecrets {
 
   def withId(id: String): this.type = {
     _internal.withId(id)
+    this
+  }
+
+  def isExternalLink: BoolField = _internal.isExternalLink
+  def withIsExternalLink(isExternalLink: Boolean): DomainElement = {
+    _internal.withIsExternalLink(isExternalLink)
     this
   }
 

--- a/shared/src/main/scala/amf/core/metamodel/domain/DomainElementModel.scala
+++ b/shared/src/main/scala/amf/core/metamodel/domain/DomainElementModel.scala
@@ -1,9 +1,9 @@
 package amf.core.metamodel.domain
 
-import amf.core.metamodel.Type.Array
+import amf.core.metamodel.Type.{Array, Bool}
 import amf.core.metamodel.document.SourceMapModel
 import amf.core.metamodel.domain.extensions.DomainExtensionModel
-import amf.core.metamodel.{Field, ModelDefaultBuilder, Obj, domain}
+import amf.core.metamodel.{Field, ModelDefaultBuilder, Obj}
 import amf.core.vocabulary.Namespace.{Document, SourceMaps}
 import amf.core.vocabulary.{Namespace, ValueType}
 
@@ -63,6 +63,11 @@ trait DomainElementModel extends Obj with ModelDefaultBuilder {
   // I need lazy evaluation here.
   // It cannot even be defined in the list of fields below
   lazy val CustomDomainProperties = Field(Array(DomainExtensionModel), Document + "customDomainProperties", ModelDoc(ModelVocabularies.AmlDoc,"customDomainProperties", "Extensions provided for a particular domain element."))
+
+  /**
+   * Marks this domain element as a reference to the element identified by the provide ID
+   */
+  val IsExternalLink = Field(Bool, Document + "isExternalLink", ModelDoc(ModelVocabularies.AmlDoc, "isExternalLink", "Marks this domain element as a reference to the actual element identified by the same URI"))
 
 }
 

--- a/shared/src/main/scala/amf/core/model/domain/DomainElement.scala
+++ b/shared/src/main/scala/amf/core/model/domain/DomainElement.scala
@@ -1,6 +1,7 @@
 package amf.core.model.domain
 
 import amf.core.metamodel.domain.DomainElementModel._
+import amf.core.model.BoolField
 import amf.core.model.domain.extensions.DomainExtension
 
 /**
@@ -16,6 +17,9 @@ trait DomainElement extends AmfObject {
 
   def withCustomDomainProperty(extensions: DomainExtension): this.type =
     add(CustomDomainProperties, extensions)
+
+  def isExternalLink: BoolField = fields.field(IsExternalLink)
+  def withIsExternalLink(isReference: Boolean): DomainElement.this.type = set(IsExternalLink, isReference)
 
   def withExtends(extend: Seq[DomainElement]): this.type = setArray(Extends, extend)
 

--- a/shared/src/main/scala/amf/core/rdf/RdfModelEmitter.scala
+++ b/shared/src/main/scala/amf/core/rdf/RdfModelEmitter.scala
@@ -156,6 +156,9 @@ class RdfModelEmitter(rdfmodel: RdfModel) extends MetaModelTypeMapping with Comm
 
     private def objectValue(subject: String, property: String, t: Type, v: Value): Unit = {
       t match {
+        // if this is an external link, emit jus the URI without the dialect class so the validation is not triggered
+        case e: DomainElementModel if v.value.isInstanceOf[DomainElement] && v.value.asInstanceOf[DomainElement].isExternalLink.option().getOrElse(false) =>
+          rdfmodel.addTriple(subject, property, v.value.asInstanceOf[DomainElement].id)
         case t: DomainElement with Linkable if t.isLink =>
           link(subject, property, t)
         case _: Obj =>
@@ -265,7 +268,7 @@ class RdfModelEmitter(rdfmodel: RdfModel) extends MetaModelTypeMapping with Comm
         elementWithLink.fields.removeField(LinkableElementModel.Target)
       }
 
-      // add the liking triple
+      // add the liking triplea
       rdfmodel.addTriple(subject, property, elementWithLink.id)
       // recursion on the object
       traverse(elementWithLink)

--- a/shared/src/main/scala/amf/plugins/document/graph/emitter/FlattenedJsonLdEmitter.scala
+++ b/shared/src/main/scala/amf/plugins/document/graph/emitter/FlattenedJsonLdEmitter.scala
@@ -95,6 +95,21 @@ class FlattenedJsonLdEmitter[T](val builder: DocBuilder[T], val options: RenderO
               ctx.emittingReferences = emission.isReference
               emission.fn(root)
             }
+
+            // Now process external links, not declared as part of the unit
+            while(pending.hasPendingExternalEmissions) {
+              val emission = pending.nextExternalEmission()
+              ctx.emittingDeclarations = emission.isDeclaration
+              ctx.emittingReferences = emission.isReference
+              emission.fn(root)
+            }
+            // new regular nodes might have been generated, annotations for example
+            while (pending.hasPendingEmissions) {
+              val emission = pending.nextEmission()
+              ctx.emittingDeclarations = emission.isDeclaration
+              ctx.emittingReferences = emission.isReference
+              emission.fn(root)
+            }
           }
       )
       ctx.emitContext(ob)
@@ -220,6 +235,7 @@ class FlattenedJsonLdEmitter[T](val builder: DocBuilder[T], val options: RenderO
     e.id = Some(id)
     e.isDeclaration = ctx.emittingDeclarations
     e.isReference = ctx.emittingReferences
+    e.isExternal = amfObject.isInstanceOf[DomainElement] && amfObject.asInstanceOf[DomainElement].isExternalLink.option().getOrElse(false)
     e
   }
 

--- a/shared/src/main/scala/amf/plugins/document/graph/emitter/JsonLdEmitter.scala
+++ b/shared/src/main/scala/amf/plugins/document/graph/emitter/JsonLdEmitter.scala
@@ -406,12 +406,17 @@ class JsonLdEmitter[T](val builder: DocBuilder[T], val options: RenderOptions)(i
     def emit(b: Part[T]): Unit = {
       cache.get(element.id) match {
         case Some(value) => b.+=(value)
-        case None        => b.obj(traverse(element, _)).foreach(cache.put(element.id, _))
+        case None  if isExternalLink(element) => {
+          b.obj(traverse(element, _))
+        } // don't add references to the cache, duplicated IDs
+        case None => b.obj(traverse(element, _)).foreach(cache.put(element.id, _))
       }
     }
 
     if (inArray) emit(b) else b.list(emit)
   }
+
+  private def isExternalLink(element: AmfObject) = element.isInstanceOf[DomainElement] && element.asInstanceOf[DomainElement].isExternalLink.option().getOrElse(false)
 
   private def extractToLink(shape: Shape, b: Part[T], inArray: Boolean = false): Unit = {
     if (!ctx.isDeclared(shape) && !ctx.isInReferencedShapes(shape)) {


### PR DESCRIPTION
Supporting emission of external links in the generated JSON-LD, providing only the ID and the required fields for ID generation