### PR TITLE
APIMF-2369: centralized JsonParser creation logic to always use JsonErrorHandler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val workspaceDirectory: File =
     case _ => Path.userHome / "mulesoft"
   }
 
-val syamlVersion = "1.0.282"
+val syamlVersion = "1.0.283"
 
 lazy val syamlJVMRef = ProjectRef(workspaceDirectory / "syaml", "syamlJVM")
 lazy val syamlJSRef = ProjectRef(workspaceDirectory / "syaml", "syamlJS")

--- a/js/src/test/scala/amf/core/parser/JsDuplicateJsonKeysTest.scala
+++ b/js/src/test/scala/amf/core/parser/JsDuplicateJsonKeysTest.scala
@@ -1,0 +1,5 @@
+package amf.core.parser
+
+import amf.client.convert.NativeOpsFromJs
+
+class JsDuplicateJsonKeysTest extends DuplicateJsonKeysTest with NativeOpsFromJs

--- a/jvm/src/test/scala/amf/core/parser/JvmDuplicateJsonKeysTest.scala
+++ b/jvm/src/test/scala/amf/core/parser/JvmDuplicateJsonKeysTest.scala
@@ -1,0 +1,5 @@
+package amf.core.parser
+
+import amf.client.convert.NativeOpsFromJvm
+
+class JvmDuplicateJsonKeysTest extends DuplicateJsonKeysTest with NativeOpsFromJvm

--- a/shared/src/main/scala/amf/core/parser/JsonParserFactory.scala
+++ b/shared/src/main/scala/amf/core/parser/JsonParserFactory.scala
@@ -1,0 +1,15 @@
+package amf.core.parser
+
+import amf.core.parser.errorhandler.{JsonErrorHandler, ParserErrorHandler}
+import org.mulesoft.lexer.{Position => SyamlPosition}
+import org.yaml.parser.JsonParser
+
+object JsonParserFactory {
+
+  def fromChars(s: CharSequence)(implicit errorhandler: ParserErrorHandler): JsonParser =
+    JsonParser(s)(JsonErrorHandler(errorhandler))
+
+  def fromCharsWithSource(s: CharSequence, sourceName: String, positionOffset: SyamlPosition = SyamlPosition.Zero)(
+      implicit errorHandler: ParserErrorHandler): JsonParser =
+    JsonParser.withSource(s, sourceName, positionOffset)(JsonErrorHandler(errorHandler))
+}

--- a/shared/src/main/scala/amf/core/parser/errorhandler/JsonErrorHandler.scala
+++ b/shared/src/main/scala/amf/core/parser/errorhandler/JsonErrorHandler.scala
@@ -1,0 +1,11 @@
+package amf.core.parser.errorhandler
+
+import amf.plugins.features.validation.CoreValidations.SyamlWarning
+import org.mulesoft.lexer.SourceLocation
+import org.yaml.model.{DefaultJsonErrorHandler, SyamlException}
+
+
+case class JsonErrorHandler(override val errorHandler: ParserErrorHandler) extends DefaultJsonErrorHandler {
+
+  override protected def onIgnoredException(location: SourceLocation, e: SyamlException): Unit = errorHandler.warning(SyamlWarning, "", e.getMessage, location)
+}

--- a/shared/src/main/scala/amf/plugins/syntax/SYamlSyntaxPlugin.scala
+++ b/shared/src/main/scala/amf/plugins/syntax/SYamlSyntaxPlugin.scala
@@ -2,7 +2,7 @@ package amf.plugins.syntax
 
 import amf.client.plugins.{AMFPlugin, AMFSyntaxPlugin}
 import amf.core.client.ParsingOptions
-import amf.core.parser.{ParsedDocument, ParserContext, SyamlParsedDocument}
+import amf.core.parser.{JsonParserFactory, ParsedDocument, ParserContext, SyamlParsedDocument}
 import amf.core.rdf.RdfModelDocument
 import amf.core.unsafe.PlatformSecrets
 import org.mulesoft.common.io.Output
@@ -40,7 +40,7 @@ object SYamlSyntaxPlugin extends AMFSyntaxPlugin with PlatformSecrets {
       platform.rdfFramework.get.syntaxToRdfModel(mediaType, text)
     } else {
       val parser = getFormat(mediaType) match {
-        case "json" => JsonParser.withSource(text, ctx.rootContextDocument)(ctx.eh)
+        case "json" => JsonParserFactory.fromCharsWithSource(text, ctx.rootContextDocument)(ctx.eh)
         case _      => YamlParser(text, ctx.rootContextDocument)(ctx.eh).withIncludeTag("!include")
       }
       val (document, comment) = parser.document() match {

--- a/shared/src/test/resources/parser/duplicate-key.json
+++ b/shared/src/test/resources/parser/duplicate-key.json
@@ -1,0 +1,33 @@
+{
+
+  "fieldValues" : [
+    {
+      "value" : "undefined"
+    ,"id" : "undefined"
+    }
+  ],
+  "address1" : "1921 Gallows Road" ,
+  "address2" : "" ,
+  "address3" : "" ,
+  "city" : "undefined" ,
+  "province" : "undefined" ,
+  "postalCode" : "undefined" ,
+  "country" : "USA" ,
+  "businessPhone" : "undefined" ,
+  "name" : "undefined" ,
+  "description" : "Eloqua" ,
+  "permissions" : "undefined" ,
+  "folderId" : "undefined" ,
+  "sourceTemplateId" : "undefined" ,
+  "createdBy" : "undefined" ,
+  "createdAt" : "undefined" ,
+  "updatedBy" : "undefined" ,
+  "updatedAt" : "undefined" ,
+  "accessedAt" : "undefined" ,
+  "scheduledFor" : "undefined" ,
+  "depth" : "minimal",
+  "address1" : "1921 Gallows Road" ,
+  "province" : "undefined" ,
+  "country" : "USA" ,
+  "depth" : "minimal"
+}

--- a/shared/src/test/scala/amf/core/parser/DuplicateJsonKeysTest.scala
+++ b/shared/src/test/scala/amf/core/parser/DuplicateJsonKeysTest.scala
@@ -1,0 +1,30 @@
+package amf.core.parser
+
+import amf.Core
+import amf.client.convert.NativeOps
+import amf.client.parse.DefaultParserErrorHandler
+import amf.core.remote.{Cache, Context}
+import amf.core.services.RuntimeCompiler
+import amf.core.unsafe.PlatformSecrets
+import org.scalatest.{AsyncFunSuite, Matchers}
+
+import scala.concurrent.ExecutionContext
+
+trait DuplicateJsonKeysTest extends AsyncFunSuite with PlatformSecrets with NativeOps with Matchers{
+
+  override implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  test("Parsed JSON with duplicate keys has several warnings") {
+    Core.init().asFuture.flatMap { _ =>
+      val errorHandler = DefaultParserErrorHandler.withRun()
+      val url = "file://shared/src/test/resources/parser/duplicate-key.json"
+      RuntimeCompiler(url, None, None, base = Context(platform), cache = Cache(), errorHandler = errorHandler).map {
+        _ =>
+          val errors = errorHandler.getErrors
+          errors.size should be(4)
+          val allAreDuplicateKeyWarnings = errors.forall(r => r.completeMessage.contains("Duplicate key") && r.level.contains("Warning"))
+          allAreDuplicateKeyWarnings shouldBe true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf/pull/618

Centralization of parsing login may be unnecessary. Changes in the construction of JsonParser and YamlParser are very rare. Besides, those clases could be instantiated directly from syaml anyway. 

Should AMF have a wrapper for these two classes? Wrappers would be useful to change yaml/json parsing library but this is very unlikely to happen.