### PR TITLE
Fixig bug in the parsing of self-encoded dialect instances using the flatten JSON-LD parser

### DIFF
--- a/adrs/0003-flattened-json-ld-parsing-emission-for-self-encoded-dialects.md
+++ b/adrs/0003-flattened-json-ld-parsing-emission-for-self-encoded-dialects.md
@@ -1,0 +1,28 @@
+# 3. Flattened JSON-LD parsing & emission for self-encoded dialects
+
+Date: 2020-09-14
+
+## Status
+
+Accepted
+
+## Context
+
+Self-encoded dialects define dialect instances which share the same ID between the instance document and the dialect 
+domain element encoded in such document. This allows the document and the encoded dialect domain element to be treated 
+as the same resource.
+
+On the other hand Flattened JSON-LD emission only renders one node for each ID.  
+
+## Decision
+
+We merge both nodes (the document and the encoded domain element) and emit the single merged node with the shared ID. 
+The merged node contains both the properties from the document and the encoded domain element. 
+
+When parsing the resulting flattened JSON-LD we parse the merged node twice: first as a domain element and then as a 
+document. Parsing the properties from the domain element ignores the properties from the document and vice-versa.  
+
+## Consequences
+
+Source maps for the encoded domain element are lost since it is the only property shared by both the domain element and 
+the document. 

--- a/shared/src/main/scala/amf/plugins/document/graph/parser/FlattenedGraphParser.scala
+++ b/shared/src/main/scala/amf/plugins/document/graph/parser/FlattenedGraphParser.scala
@@ -112,8 +112,10 @@ class FlattenedGraphParser()(implicit val ctx: GraphParserContext) extends Graph
       val parsed = for {
         id           <- retrieveId(rootNode, ctx)
         encodesModel <- retrieveTypeIgnoring(id, rootNode, BaseUnitModel.`type` :+ (Namespace.Meta + "DialectInstance"))
-        unitModel    <- retrieveTypeIgnoring(id, rootNode, encodesModel.`type`)
-        encoded      <- parseRootNodeWithModel(rootNode, encodesModel)
+        // we need to pass the doc namespaces so a change in the order of the declaration of a self-encoded domain-element
+        // does not take precedence over the AML document models
+        unitModel    <- retrieveTypeFrom(id, rootNode, allDocNamespaces)
+        _            <- parseRootNodeWithModel(rootNode, encodesModel)
         baseUnit     <- parseRootNodeWithModel(rootNode, unitModel)
       } yield {
         baseUnit
@@ -125,6 +127,8 @@ class FlattenedGraphParser()(implicit val ctx: GraphParserContext) extends Graph
     private def parseBaseUnit(rootNode: YMap): Option[BaseUnit] = {
       val parsed = for {
         id     <- retrieveId(rootNode, ctx)
+        // we don't need to pass the doc namespace, since a potential AML doc will always have precedence
+        // over the regular basic document model due to the way we order potential models when checking types
         model  <- retrieveType(id, rootNode)
         parsed <- parseNode(rootNode, id, model)
       } yield {
@@ -159,9 +163,22 @@ class FlattenedGraphParser()(implicit val ctx: GraphParserContext) extends Graph
 
     private def retrieveType(id: String, map: YMap): Option[Obj] = retrieveTypeIgnoring(id, map, Nil)
 
+    private def retrieveTypeFrom(id: String, map: YMap, from: Seq[ValueType]): Option[Obj] = {
+      val expectedIris = from.map(_.iri())
+      this.retrieveTypeCondition(id, map, (t) => expectedIris.contains(t))
+    }
+
     private def retrieveTypeIgnoring(id: String, map: YMap, ignored: Seq[ValueType]): Option[Obj] = {
       val ignoredIris = ignored.map(_.iri())
-      val typeIris    = ts(map, id).diff(ignoredIris)
+      this.retrieveTypeCondition(id, map, (t) => !ignoredIris.contains(t))
+    }
+
+    private def retrieveTypeCondition(id: String, map: YMap, pred: (String) => Boolean): Option[Obj] = {
+      // this returns a certain order, we will return the first one that matches, but many could match
+      // first non-documents (including AML documents, dialect instances, dialects, vocabs, etc) are returned
+      // then the base document models are returned in sorted order: Document, Fragment, Module
+      val typeIris    = ts(map, id).filter(pred) // we are filtering the list with the provided condition
+
       typeIris.find(findType(_).isDefined) match {
         case Some(t) => findType(t)
         case None =>

--- a/shared/src/main/scala/amf/plugins/document/graph/parser/FlattenedGraphParser.scala
+++ b/shared/src/main/scala/amf/plugins/document/graph/parser/FlattenedGraphParser.scala
@@ -114,9 +114,9 @@ class FlattenedGraphParser()(implicit val ctx: GraphParserContext) extends Graph
         encodesModel <- retrieveTypeIgnoring(id, rootNode, BaseUnitModel.`type` :+ (Namespace.Meta + "DialectInstance"))
         // we need to pass the doc namespaces so a change in the order of the declaration of a self-encoded domain-element
         // does not take precedence over the AML document models
-        unitModel    <- retrieveTypeFrom(id, rootNode, allDocNamespaces)
-        _            <- parseRootNodeWithModel(rootNode, encodesModel)
-        baseUnit     <- parseRootNodeWithModel(rootNode, unitModel)
+        unitModel <- retrieveTypeFrom(id, rootNode, documentIris)
+        _         <- parseRootNodeWithModel(rootNode, encodesModel)
+        baseUnit  <- parseRootNodeWithModel(rootNode, unitModel)
       } yield {
         baseUnit
       }
@@ -126,7 +126,7 @@ class FlattenedGraphParser()(implicit val ctx: GraphParserContext) extends Graph
 
     private def parseBaseUnit(rootNode: YMap): Option[BaseUnit] = {
       val parsed = for {
-        id     <- retrieveId(rootNode, ctx)
+        id <- retrieveId(rootNode, ctx)
         // we don't need to pass the doc namespace, since a potential AML doc will always have precedence
         // over the regular basic document model due to the way we order potential models when checking types
         model  <- retrieveType(id, rootNode)
@@ -173,11 +173,18 @@ class FlattenedGraphParser()(implicit val ctx: GraphParserContext) extends Graph
       this.retrieveTypeCondition(id, map, (t) => !ignoredIris.contains(t))
     }
 
+    /**
+      * Returns the first type defined in the @type entry from a YMap that matches the given predicate
+      * @param id id for error reporting
+      * @param map input ymap
+      * @param pred predicate
+      * @return Option for the first matching type as an Obj
+      */
     private def retrieveTypeCondition(id: String, map: YMap, pred: (String) => Boolean): Option[Obj] = {
       // this returns a certain order, we will return the first one that matches, but many could match
       // first non-documents (including AML documents, dialect instances, dialects, vocabs, etc) are returned
       // then the base document models are returned in sorted order: Document, Fragment, Module
-      val typeIris    = ts(map, id).filter(pred) // we are filtering the list with the provided condition
+      val typeIris = ts(map, id).filter(pred) // we are filtering the list with the provided condition
 
       typeIris.find(findType(_).isDefined) match {
         case Some(t) => findType(t)

--- a/shared/src/main/scala/amf/plugins/document/graph/parser/GraphParserHelpers.scala
+++ b/shared/src/main/scala/amf/plugins/document/graph/parser/GraphParserHelpers.scala
@@ -9,7 +9,7 @@ import amf.core.model.domain.{AmfElement, Annotation}
 import amf.core.parser.{Annotations, _}
 import amf.core.vocabulary.Namespace
 import amf.core.vocabulary.Namespace.SourceMaps
-import amf.plugins.features.validation.CoreValidations.{MissingIdInNode, MissingTypeInNode}
+import amf.plugins.features.validation.CoreValidations.{MissingIdInNode, MissingTypeInNode, namespace}
 import org.yaml.convert.YRead.SeqNodeYRead
 import org.yaml.model._
 
@@ -53,10 +53,17 @@ trait GraphParserHelpers extends GraphContextHelper {
     result
   }
 
-  protected def ts(map: YMap, id: String)(implicit ctx: GraphParserContext): Seq[String] = {
-    val namespaces =
-      Seq("Document", "Fragment", "Module", "Unit").map(docElement => (Namespace.Document + docElement).iri())
+  // declared so they can be referenced from the retrieveType* functions
+  val amlDocNamespaces =
+    Seq("DialectInstance", "DialectInstanceFragment", "DialectInstanceLibrary", "DialectInstancePatch", "DialectLibrary", "DialectFragment","Dialect", "Vocabulary").map((docElement) => (Namespace.Meta + docElement))
 
+  val baseDocNamespaces =
+    Seq("Document", "Fragment", "Module", "Unit").map((docElement) => (Namespace.Document + docElement))
+
+  val allDocNamespaces = amlDocNamespaces ++ baseDocNamespaces
+
+  protected def ts(map: YMap, id: String)(implicit ctx: GraphParserContext): Seq[String] = {
+    val namespaces = baseDocNamespaces.map(docElement => docElement.iri())
     val documentTypesSet: Set[String] = (namespaces ++ namespaces.map(compactUriFromContext(_))).toSet
 
     map.key("@type") match {


### PR DESCRIPTION
The problem happens when we have an arbitrary JSON-LD without any order in the @type array and a self-encoded dialect instance that has types for documents and dialect domain elements.

The parsing tries to parse first the non-document dialect domain element and then find the containing document model.
The logic finding valid type models sorts first domain element and then document models, but AML documents are treated as domain elements.
If after finding the dialect domain element (usually from a vocabulary) another dialect domain element appears before the AML document in the list of @types, the base unit document will not be found and a default Document BaseUnit will be created silently.

The provided fix passes explicitly the list of expected document elements, including AML documents, when parsing the base unit of a self-encoded dialect instance.
