### PR TITLE
APIMF-2829: support for self encoded dialect instances without dialect loaded to registry. Hacky but talked it over with Pedro. Test is in amf-client as I can't instance an RDFModel from this artifact.

### DIFF
--- a/shared/src/main/scala/amf/core/rdf/helper/PluginEntitiesFacade.scala
+++ b/shared/src/main/scala/amf/core/rdf/helper/PluginEntitiesFacade.scala
@@ -18,7 +18,7 @@ class PluginEntitiesFacade(ctx: ParserContext) {
     typeModel.isInstanceOf[DocumentModel] || typeModel.isInstanceOf[EncodesModel] || typeModel
       .isInstanceOf[DeclaresModel] || typeModel.isInstanceOf[BaseUnitModel]
 
-  def retrieveType(id: String, node: Node, findBaseUnit: Boolean = false): Option[Obj] = {
+  def retrieveType(id: String, node: Node, findBaseUnit: Boolean = false, visitedSelfEncoded: Boolean = false): Option[Obj] = {
     val types = sorter.sortedClassesOf(node)
 
     val foundType = types.find { t =>
@@ -32,7 +32,7 @@ class PluginEntitiesFacade(ctx: ParserContext) {
     } orElse {
       // if I cannot find it, I will return the matching one directly, this is used
       // in situations where the references a reified, for example, in the canonical web api spec
-      types.find(findType(_).isDefined)
+      types.find(findType(_).isDefined && !visitedSelfEncoded)
     }
 
     foundType match {


### PR DESCRIPTION
This fix is only for the case when we parse an RDF coming from a self encoded instance for which we can't find any of the non unit descendant classes of the encodes node in our metadata registry. This may happen because:
- There is no dialect that declares a node mapping with that iri
- The dialect that does declare a suitable node mapping is not registered in the DialectRegistry.

Test for this is in: https://github.com/aml-org/amf/pull/840