### PR TITLE
fix some javadoc typos in amf-core

### DIFF
--- a/js/src/main/scala/amf/core/remote/server/Path.scala
+++ b/js/src/main/scala/amf/core/remote/server/Path.scala
@@ -31,7 +31,7 @@ object Path extends js.Object {
   /**
     * The right-most parameter is considered {to}.  Other parameters are considered an array of {from}.
     *
-    * Starting from leftmost {from} paramter, resolves {to} to an absolute path.
+    * Starting from leftmost {from} parameter, resolves {to} to an absolute path.
     *
     * If {to} isn't already absolute, {from} arguments are prepended in right to left order, until an absolute path is found. If after using all {from} paths still no absolute path is found, the current working directory is used as well. The resulting path is normalized, and trailing slashes are removed unless the path gets resolved to the root directory.
     *

--- a/jvm/src/main/scala/amf/core/remote/EcmaEncoder.scala
+++ b/jvm/src/main/scala/amf/core/remote/EcmaEncoder.scala
@@ -150,7 +150,7 @@ object EcmaEncoder {
           var utf8Tail    = 0
           var ucs4Char    = 0
           var minUcs4Char = 0
-          if ((B & 0xC0) == 0x80) { // First  UTF-8 should be ouside 0x80..0xBF
+          if ((B & 0xC0) == 0x80) { // First  UTF-8 should be outside 0x80..0xBF
             throw uriError
           } else if ((B & 0x20) == 0) {
             utf8Tail = 1

--- a/jvm/src/main/scala/amf/core/remote/JvmPlatform.scala
+++ b/jvm/src/main/scala/amf/core/remote/JvmPlatform.scala
@@ -51,16 +51,16 @@ class JvmPlatform extends Platform {
     }
   }
 
-  /** encodes a complete uri. Not encodes chars like / */
+  /** encodes a complete URI, does not encodes chars like '/' */
   override def encodeURI(url: String): String = EcmaEncoder.encode(url)
 
-  /** encodes a uri component, including chars like / and : */
+  /** encodes a URI component, including chars like '/' and ':' */
   override def encodeURIComponent(url: String): String = EcmaEncoder.encode(url, fullUri = false)
 
-  /** decode a complete uri. */
+  /** decode a complete URI. */
   override def decodeURI(url: String): String = EcmaEncoder.decode(url)
 
-  /** decodes a uri component */
+  /** decodes a URI component */
   override def decodeURIComponent(url: String): String = EcmaEncoder.decode(url, fullUri = false)
 
   override def normalizeURL(url: String): String = encodeURI(url)

--- a/shared/src/main/scala/amf/client/model/document/BaseUnit.scala
+++ b/shared/src/main/scala/amf/client/model/document/BaseUnit.scala
@@ -31,7 +31,7 @@ trait BaseUnit extends AmfObjectWrapper with PlatformSecrets {
   /** Returns the file location for the document that has been parsed to generate this model */
   def location: String = _internal.location().getOrElse("")
 
-  /** Returns the usage comment for de element */
+  /** Returns element's usage comment */
   def usage: StrField = _internal.usage
 
   /** Returns the version. */

--- a/shared/src/main/scala/amf/client/parse/Parser.scala
+++ b/shared/src/main/scala/amf/client/parse/Parser.scala
@@ -89,7 +89,7 @@ class Parser(vendor: String, mediaType: String, private val env: Option[Environm
   def reportValidation(profile: ProfileName): ClientFuture[ValidationReport] = report(profile)
 
   /**
-    * Generates a custom validaton profile as specified in the input validation profile file
+    * Generates a custom validation profile as specified in the input validation profile file
     * @param profile the profile to be parsed
     * @param customProfilePath path to the custom profile file
     * @return the AMF validation report

--- a/shared/src/main/scala/amf/client/plugins/AMFFeaturePlugin.scala
+++ b/shared/src/main/scala/amf/client/plugins/AMFFeaturePlugin.scala
@@ -16,8 +16,8 @@ trait AMFFeaturePlugin extends AMFPlugin {
 
   /**
     * Callback invoked for every linked document being parsed as result of the client invocation of the parser
-    * @param url URL of the documen being parsed
-    * @param content Raw content being parsed after fetching it fromt the remote location
+    * @param url URL of the document being parsed
+    * @param content Raw content being parsed after fetching it from the remote location
     * @param referenceKind Type of reference for the content
     */
   def onBeginDocumentParsing(url: String, content: Content, referenceKind: ReferenceKind): Content =
@@ -31,7 +31,7 @@ trait AMFFeaturePlugin extends AMFPlugin {
   def onSyntaxParsed(url: String, ast: ParsedDocument): ParsedDocument = ast
 
   /**
-    * Callabck being invoked for every successful domain model being parsed for any linked document
+    * Callback being invoked for every successful domain model being parsed for any linked document
     * @param url URL of the document being parsed
     * @param unit Parsed domain unit
     */

--- a/shared/src/main/scala/amf/client/resource/ResourceLoader.scala
+++ b/shared/src/main/scala/amf/client/resource/ResourceLoader.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation.JSExportAll
 @JSExportAll
 trait ResourceLoader {
 
-  /** Fetch specified resource and return associated content. Resource should have benn previously accepted. */
+  /** Fetch specified resource and return associated content. Resource should have been previously accepted. */
   /** If the resource not exists, you should return a future failed with an ResourceNotFound exception. */
   def fetch(resource: String): ClientFuture[Content]
 

--- a/shared/src/main/scala/amf/core/annotations/DeclaredAndReferencedShapes.scala
+++ b/shared/src/main/scala/amf/core/annotations/DeclaredAndReferencedShapes.scala
@@ -4,7 +4,7 @@ import amf.core.model.domain.{Annotation, DomainElement}
 
 /**
   * Used to maintain shapes that where declarations or references, used for optimizing emission.
-  * These shapes may latter be extracted to declares arrray in jsonld and avoid multiple emissions.
+  * These shapes may latter be extracted to declares array in jsonld and avoid multiple emissions.
   * These annotations must not be serialized into jsonld.
   */
 case class References(references: Seq[String]) extends Annotation

--- a/shared/src/main/scala/amf/core/emitter/BaseEmitters.scala
+++ b/shared/src/main/scala/amf/core/emitter/BaseEmitters.scala
@@ -132,7 +132,7 @@ package object BaseEmitters {
         case _ : NumberFormatException => (text, YType.Str)
       }
 
-    // Hack to fix difference in float emittion between JS and Java (Java prints '.0')
+    // Hack to fix difference in float emission between JS and Java (Java prints '.0')
     private def floatValue(text: String) = {
       try formatFloatValue(text)
       catch {

--- a/shared/src/main/scala/amf/core/model/domain/ExternalSourceElement.scala
+++ b/shared/src/main/scala/amf/core/model/domain/ExternalSourceElement.scala
@@ -17,7 +17,7 @@ trait ExternalSourceElement extends DomainElement {
   }
 
   // this its dynamic, because when graph emitter is going to serialize the raw field, first we need to check if its a link to an external fragment.
-  // In that case the raw should't be emitted, and it should be only a ref to the external domain element with the raw. This its to avoid duplicated json and xml schemas definitions
+  // In that case the raw shouldn't be emitted, and it should be only a ref to the external domain element with the raw. This its to avoid duplicated json and xml schemas definitions
   // todo: antonio add comment.
 
   def isLinkToSource = fields.entry(ReferenceId).isDefined

--- a/shared/src/main/scala/amf/core/parser/Annotations.scala
+++ b/shared/src/main/scala/amf/core/parser/Annotations.scala
@@ -97,8 +97,8 @@ object Annotations {
 
   }
 
-  // todo: temp method to keep compatibility against previous range serializacion logic.
-  // We should discuss if always use the range of the YNode, or always use the range of the ynode member.
+  // todo: temp method to keep compatibility against previous range serialization logic.
+  // We should discuss if always use the range of the YNode, or always use the range of the Ynode member.
   def valueNode(node: YNode): Annotations = apply(node.value) += SourceNode(node)
 
   def apply(annotation: Annotation): Annotations = new Annotations() += annotation

--- a/shared/src/main/scala/amf/core/parser/Fields.scala
+++ b/shared/src/main/scala/amf/core/parser/Fields.scala
@@ -286,7 +286,7 @@ class Value(var value: AmfElement, val annotations: Annotations) {
                       case _        => None
                     }
                     unresolved += (element
-                      .asInstanceOf[Linkable] -> syntax) // we need to collect the linkables unresolved instances,torun the after resolve trigger. This will end the father parser logic when its necessary
+                      .asInstanceOf[Linkable] -> syntax) // we need to collect the linkables unresolved instances, to run the after resolve trigger. This will end the father parser logic when its necessary
                     resolved.resolveUnreferencedLink(linkable.refName,
                                                      linkable.annotations,
                                                      element,

--- a/shared/src/main/scala/amf/core/validation/core/ValidationSpecification.scala
+++ b/shared/src/main/scala/amf/core/validation/core/ValidationSpecification.scala
@@ -112,10 +112,10 @@ case class ValidationSpecification(name: String,
                                    targetObject: Seq[String] = Seq.empty,
                                    /**
                                      * Union of constraints passed as URIs
-                                     * to the contraints in the union
+                                     * to the constraints in the union
                                      */
                                    unionConstraints: Seq[String] = Seq.empty,
-                                   // Logical constraints here, or contraints are collected in the union above
+                                   // Logical constraints here, or constraints are collected in the union above
                                    andConstraints: Seq[String] = Seq.empty,
                                    xoneConstraints: Seq[String] = Seq.empty,
                                    notConstraint: Option[String] = None,

--- a/shared/src/test/scala/amf/core/parser/FieldsTest.scala
+++ b/shared/src/test/scala/amf/core/parser/FieldsTest.scala
@@ -138,7 +138,7 @@ class FieldsTest extends FunSuite with Matchers {
     strDefined.isNullOrEmpty should be(true)
     strDefined.is("") should be(false)
     strDefined.is(_ == "") should be(false)
-    strDefined.is(_ == null) should be(false) // option() its empty, so fold alwarys return false.
+    strDefined.is(_ == null) should be(false) // option() its empty, so fold always return false.
 
     fields.set("/", IntProperty, AmfScalar(null))
     val intDefined: IntField = fields.field(IntProperty)


### PR DESCRIPTION
This should improve readability and remove some code smells from SonarQube.
All typos fixed were located inside comments, so code hasn't been touched. (although there are some typos in code methods and names).