### PR TITLE
APIMF-3048: add javadoc and remove private[amf]

### DIFF
--- a/shared/src/main/scala/amf/client/remod/AMFGraphConfiguration.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFGraphConfiguration.scala
@@ -14,7 +14,7 @@ import amf.plugins.document.graph.{AMFGraphParsePlugin, AMFGraphRenderPlugin}
 import scala.concurrent.ExecutionContext
 // all constructors only visible from amf. Users should always use builders or defaults
 
-private[amf] object AMFGraphConfiguration {
+object AMFGraphConfiguration {
 
   def empty(): AMFGraphConfiguration = {
     new AMFGraphConfiguration(
@@ -29,10 +29,14 @@ private[amf] object AMFGraphConfiguration {
 
   /**
     * Predefined AMF core environment with
-    * AMF Resolvers predefined {@link amf.client.remod.amfcore.config.AMFResolvers.predefined()}
+    * AMF Resolvers predefined {@link amf.client.remod.amfcore.config.AMFResolvers.predefined predefined}
+    *
     * Default error handler provider that will create a {@link amf.client.parse.DefaultParserErrorHandler}
+    *
     * Empty AMF Registry: {@link amf.client.remod.amfcore.registry.AMFRegistry.empty}
+    *
     * MutedLogger: {@link amf.client.remod.amfcore.config.MutedLogger}
+    *
     * Without Any listener
     */
   def predefined(): AMFGraphConfiguration = {
@@ -57,13 +61,21 @@ private[amf] object AMFGraphConfiguration {
   }
 }
 
-//TODO: ARM - delete private[amf]
-private[amf] class AMFGraphConfiguration(override private[amf] val resolvers: AMFResolvers,
-                                         override private[amf] val errorHandlerProvider: ErrorHandlerProvider,
-                                         override private[amf] val registry: AMFRegistry,
-                                         override private[amf] val logger: AMFLogger,
-                                         override private[amf] val listeners: Set[AMFEventListener],
-                                         override private[amf] val options: AMFOptions)
+/**
+  * Base AMF configuration object
+  * @param resolvers {@link amf.client.remod.amfcore.config.AMFResolvers}
+  * @param errorHandlerProvider {@link amf.client.remod.ErrorHandlerProvider}
+  * @param registry {@link amf.client.remod.amfcore.registry.AMFRegistry}
+  * @param logger {@link amf.client.remod.amfcore.config.AMFLogger}
+  * @param listeners a Set of {@link amf.client.remod.amfcore.config.AMFEventListener}
+  * @param options {@link amf.client.remod.amfcore.config.AMFOptions}
+  */
+class AMFGraphConfiguration private[amf] (override private[amf] val resolvers: AMFResolvers,
+                                          override private[amf] val errorHandlerProvider: ErrorHandlerProvider,
+                                          override private[amf] val registry: AMFRegistry,
+                                          override private[amf] val logger: AMFLogger,
+                                          override private[amf] val listeners: Set[AMFEventListener],
+                                          override private[amf] val options: AMFOptions)
     extends BaseAMFConfigurationSetter(resolvers, errorHandlerProvider, registry, logger, listeners, options) { // break platform into more specific classes?
 
   def createClient(): AMFGraphClient = new AMFGraphClient(this)
@@ -103,10 +115,10 @@ private[amf] class AMFGraphConfiguration(override private[amf] val resolvers: AM
 
   /**
     * AMF internal method just to facilitate the construction
-    * @param pipelines
+    * @param pipelines a list of {@link amf.core.resolution.pipelines.ResolutionPipeline}s
     * @return
     */
-  private[amf] def withTransformationPipelines(pipelines: List[TransformationPipeline]): AMFGraphConfiguration =
+  def withTransformationPipelines(pipelines: List[TransformationPipeline]): AMFGraphConfiguration =
     super._withTransformationPipelines(pipelines)
 
   /**

--- a/shared/src/main/scala/amf/client/remod/AMFGraphConfiguration.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFGraphConfiguration.scala
@@ -11,6 +11,7 @@ import amf.internal.reference.UnitCache
 import amf.internal.resource.ResourceLoader
 import amf.plugins.document.graph.{AMFGraphParsePlugin, AMFGraphRenderPlugin}
 
+import java.rmi.registry.LocateRegistry.getRegistry
 import scala.concurrent.ExecutionContext
 // all constructors only visible from amf. Users should always use builders or defaults
 
@@ -28,16 +29,14 @@ object AMFGraphConfiguration {
   }
 
   /**
-    * Predefined AMF core environment with
-    * AMF Resolvers predefined {@link amf.client.remod.amfcore.config.AMFResolvers.predefined predefined}
-    *
-    * Default error handler provider that will create a {@link amf.client.parse.DefaultParserErrorHandler}
-    *
-    * Empty AMF Registry: {@link amf.client.remod.amfcore.registry.AMFRegistry.empty}
-    *
-    * MutedLogger: {@link amf.client.remod.amfcore.config.MutedLogger}
-    *
-    * Without Any listener
+    * Predefined AMF core environment with:
+    * <ul>
+    *   <li>AMF Resolvers predefined {@link amf.client.remod.amfcore.config.AMFResolvers.predefined predefined}</li>
+    *   <li>Default error handler provider that will create a {@link amf.client.parse.DefaultParserErrorHandler}</li>
+    *   <li>Empty AMF Registry: {@link amf.client.remod.amfcore.registry.AMFRegistry.empty}</li>
+    *   <li>MutedLogger: {@link amf.client.remod.amfcore.config.MutedLogger}</li>
+    *   <li>Without Any listener</li>
+    * </ul>
     */
   def predefined(): AMFGraphConfiguration = {
     new AMFGraphConfiguration(

--- a/shared/src/main/scala/amf/client/remod/AMFSimpleCompiler.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFSimpleCompiler.scala
@@ -11,6 +11,11 @@ private[remod] abstract class AMFSimpleCompiler {
   def compile: Future[AMFResult]
 }
 
+/**
+  *
+  * @param bu {@link amf.core.model.document.BaseUnit} returned from AMF parse or transform
+  * @param result the resultant {@link amf.core.validation.AMFValidationReport} of the BaseUnit
+  */
 case class AMFResult(bu: BaseUnit, result: AMFValidationReport) {
 
   def conforms = result.conforms

--- a/shared/src/main/scala/amf/client/remod/ErrorHandlerProvider.scala
+++ b/shared/src/main/scala/amf/client/remod/ErrorHandlerProvider.scala
@@ -3,7 +3,7 @@ package amf.client.remod
 import amf.client.parse.DefaultParserErrorHandler
 import amf.core.errorhandling.ErrorHandler
 
-private[amf] trait ErrorHandlerProvider {
+trait ErrorHandlerProvider {
 
   // Returns a new instance of error handler to collect results
   def errorHandler(): ErrorHandler

--- a/shared/src/main/scala/amf/client/remod/amfcore/config/AMFEventListener.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/config/AMFEventListener.scala
@@ -12,6 +12,9 @@ import amf.core.validation.AMFValidationReport
 
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 
+/**
+  * Defines an event listener linked to a specific {@link amf.client.remod.amfcore.config.EventKind}
+  */
 private[amf] trait AMFEventListener {
   def notifyEvent(event: AMFEvent)
 }

--- a/shared/src/main/scala/amf/client/remod/amfcore/config/AMFLogger.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/config/AMFLogger.scala
@@ -3,7 +3,7 @@ package amf.client.remod.amfcore.config
 /**
   * AMF Logger object
   */
-class AMFLogger {
+private[amf] class AMFLogger {
 
   private def log(message: String, severity: LogSeverity, source: String) = {}
 

--- a/shared/src/main/scala/amf/client/remod/amfcore/config/AMFLogger.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/config/AMFLogger.scala
@@ -1,7 +1,9 @@
 package amf.client.remod.amfcore.config
 
-//TODO: ARM remove private[amf]
-private[amf] class AMFLogger {
+/**
+  * AMF Logger object
+  */
+class AMFLogger {
 
   private def log(message: String, severity: LogSeverity, source: String) = {}
 

--- a/shared/src/main/scala/amf/client/remod/amfcore/config/AMFOptions.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/config/AMFOptions.scala
@@ -1,5 +1,10 @@
 package amf.client.remod.amfcore.config
 
+/**
+  * A set of options to customize parsing and rendering
+  * @param parsingOptions {@link amf.client.remod.amfcore.config.ParsingOptions}
+  * @param renderOptions {@link amf.client.remod.amfcore.config.RenderOptions}
+  */
 private[amf] case class AMFOptions(parsingOptions: ParsingOptions,
                                    renderOptions: RenderOptions /*, private[amf] var env:AmfEnvironment*/ ) {
   //  def withPrettyPrint(): AmfEnvironment = {
@@ -11,5 +16,7 @@ private[amf] case class AMFOptions(parsingOptions: ParsingOptions,
 }
 
 object AMFOptions {
+
+  /** Creates a default {@link amf.client.remod.amfcore.config.AMFOptions} */
   def default() = new AMFOptions(ParsingOptions(), RenderOptions())
 }

--- a/shared/src/main/scala/amf/client/remod/amfcore/config/AMFResolvers.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/config/AMFResolvers.scala
@@ -10,22 +10,49 @@ import amf.internal.resource.ResourceLoader
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/**
+  * Configuration object for resolvers
+  * @param resourceLoaders a list of {@link amf.internal.resource.ResourceLoader} to use
+  * @param unitCache a {@link amf.internal.reference.UnitCache} that stores {@link amf.core.model.document.BaseUnit} resolved
+  * @param executionContext the {@link amf.client.execution.BaseExecutionEnvironment} to use
+  */
 private[amf] case class AMFResolvers(resourceLoaders: List[ResourceLoader],
                                      val unitCache: Option[UnitCache],
                                      val executionContext: BaseExecutionEnvironment) {
 
+  /**
+    *
+    * @param resourceLoader
+    * @return
+    */
   def withResourceLoader(resourceLoader: ResourceLoader): AMFResolvers = {
     copy(resourceLoaders = resourceLoader +: resourceLoaders)
   }
 
+  /**
+    *
+    * @param newLoaders
+    * @return
+    */
   def withResourceLoaders(newLoaders: List[ResourceLoader]): AMFResolvers = {
     copy(resourceLoaders = newLoaders)
   }
 
+  /**
+    *
+    * @param cache
+    * @return
+    */
   def withCache(cache: UnitCache): AMFResolvers = {
     copy(unitCache = Some(cache))
   }
 
+  /**
+    *
+    * @param url
+    * @param executionContext
+    * @return
+    */
   def resolveContent(url: String)(implicit executionContext: ExecutionContext): Future[Content] = {
     loaderConcat(url, resourceLoaders.filter(_.accepts(url)))
   }

--- a/shared/src/main/scala/amf/client/remod/amfcore/config/ParsingOptions.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/config/ParsingOptions.scala
@@ -4,38 +4,32 @@ import amf.core.client.{ParsingOptions => LegacyParsingOptions}
 /**
   * Immutable implementation of parsing options
   */
-private[amf] case class ParsingOptions(amfJsonLdSerialization: Boolean = true,
-                                       baseUnitUrl: Option[String] = None,
-                                       maxYamlReferences: Option[Long] = None) {
+case class ParsingOptions private[amf] (amfJsonLdSerialization: Boolean = true,
+                                        baseUnitUrl: Option[String] = None,
+                                        maxYamlReferences: Option[Long] = None) {
 
-  /**
-    * Parse specific AMF JSON-LD serialization
-    * @return
-    */
+  /** Parse specific AMF JSON-LD serialization */
   def withoutAmfJsonLdSerialization: ParsingOptions = copy(amfJsonLdSerialization = false)
 
-  /**
-    * Parse regular JSON-LD serialization
-    * @return
-    */
+  /** Parse regular JSON-LD serialization */
   def withAmfJsonLdSerialization: ParsingOptions = copy(amfJsonLdSerialization = true)
 
+  /** Include the BaseUnit Url */
   def withBaseUnitUrl(baseUnit: String): ParsingOptions = copy(baseUnitUrl = Some(baseUnit))
 
+  /** Exclude the BaseUnit Url */
   def withoutBaseUnitUrl(): ParsingOptions = copy(baseUnitUrl = None)
 
-  /**
-    * Defines an upper bound of yaml alias that will be resolved when parsing a DataNode
-    */
+  /** Defines an upper bound of yaml alias that will be resolved when parsing a DataNode */
   def setMaxYamlReferences(value: Long): ParsingOptions = copy(maxYamlReferences = Some(value))
 
-  def isAmfJsonLdSerilization: Boolean   = amfJsonLdSerialization
+  def isAmfJsonLdSerialization: Boolean  = amfJsonLdSerialization
   def definedBaseUrl: Option[String]     = baseUnitUrl
   def getMaxYamlReferences: Option[Long] = maxYamlReferences
 
 }
 
-private[amf] object ParsingOptionsConverter {
+object ParsingOptionsConverter {
   def toLegacy(options: ParsingOptions): LegacyParsingOptions = {
     val mutableOptions = new LegacyParsingOptions()
     if (!options.amfJsonLdSerialization) mutableOptions.withoutAmfJsonLdSerialization

--- a/shared/src/main/scala/amf/client/remod/amfcore/config/ParsingOptions.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/config/ParsingOptions.scala
@@ -29,7 +29,7 @@ case class ParsingOptions private[amf] (amfJsonLdSerialization: Boolean = true,
 
 }
 
-object ParsingOptionsConverter {
+private[amf] object ParsingOptionsConverter {
   def toLegacy(options: ParsingOptions): LegacyParsingOptions = {
     val mutableOptions = new LegacyParsingOptions()
     if (!options.amfJsonLdSerialization) mutableOptions.withoutAmfJsonLdSerialization

--- a/shared/src/main/scala/amf/client/remod/amfcore/config/RenderOptions.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/config/RenderOptions.scala
@@ -1,11 +1,11 @@
 package amf.client.remod.amfcore.config
 
-import amf.core.errorhandling.{ErrorHandler, UnhandledErrorHandler}
 import amf.core.metamodel.Field
+
 /**
   * Immutable implementation of render options
   */
-private[amf] case class RenderOptions(
+case class RenderOptions private[amf] (
     compactedEmission: Boolean = true,
     sources: Boolean = false,
     compactUris: Boolean = false,
@@ -20,44 +20,61 @@ private[amf] case class RenderOptions(
     shapeRenderOptions: ShapeRenderOptions = ShapeRenderOptions()
 ) {
 
+  /** Include CompactedEmission when rendering to graph. */
   def withCompactedEmission: RenderOptions = copy(compactedEmission = true)
 
+  /** Exclude CompactedEmission when rendering to graph. */
   def withoutCompactedEmission: RenderOptions = copy(compactedEmission = false)
 
+  /** Include PrettyPrint when rendering to graph. */
   def withPrettyPrint: RenderOptions = copy(prettyPrint = true)
 
+  /** Exclude PrettyPrint when rendering to graph. */
   def withoutPrettyPrint: RenderOptions = copy(prettyPrint = true)
 
   /** Include source maps when rendering to graph. */
   def withSourceMaps: RenderOptions = copy(sources = true)
 
-  /** Include source maps when rendering to graph. */
+  /** Exclude source maps when rendering to graph. */
   def withoutSourceMaps: RenderOptions = copy(sources = false)
 
+  /** Include CompactUris when rendering to graph. */
   def withCompactUris: RenderOptions = copy(compactUris = true)
 
+  /** Exclude CompactUris when rendering to graph. */
   def withoutCompactUris: RenderOptions = copy(compactUris = false)
 
+  /** Include RawSourceMaps when rendering to graph. */
   def withRawSourceMaps: RenderOptions = copy(rawSourceMaps = true)
 
+  /** Exclude RawSourceMaps when rendering to graph. */
   def withoutRawSourceMaps: RenderOptions = copy(rawSourceMaps = false)
 
+  /** Include Validation when rendering to graph. */
   def withValidation: RenderOptions = copy(validating = true)
 
-  def withNodeIds: RenderOptions = copy(emitNodeIds = true)
-
-  def withoutNodeIds: RenderOptions = copy(emitNodeIds = false)
-
+  /** Exclude Validation when rendering to graph. */
   def withoutValidation: RenderOptions = copy(validating = false)
 
+  /** Include Node IDs when rendering to graph. */
+  def withNodeIds: RenderOptions = copy(emitNodeIds = true)
+
+  /** Exclude Node IDs when rendering to graph. */
+  def withoutNodeIds: RenderOptions = copy(emitNodeIds = false)
+
+  /** Apply function to filter fields when rendering to graph. */
   def withFilterFieldsFunc(f: Field => Boolean): RenderOptions = copy(filterFields = f)
 
-  def withoutAmfJsonLdSerialization: RenderOptions = copy(amfJsonLdSerialization = false)
-
+  /** Include AmfJsonLdSerialization when rendering to graph. */
   def withAmfJsonLdSerialization: RenderOptions = copy(amfJsonLdSerialization = true)
 
+  /** Exclude AmfJsonLdSerialization when rendering to graph. */
+  def withoutAmfJsonLdSerialization: RenderOptions = copy(amfJsonLdSerialization = false)
+
+  /** Include FlattenedJsonLd when rendering to graph. */
   def withFlattenedJsonLd: RenderOptions = copy(flattenedJsonLd = true)
 
+  /** Exclude FlattenedJsonLd when rendering to graph. */
   def withoutFlattenedJsonLd: RenderOptions = copy(flattenedJsonLd = false)
 
   def isFlattenedJsonLd: Boolean = flattenedJsonLd
@@ -66,7 +83,7 @@ private[amf] case class RenderOptions(
   def isCompactUris: Boolean             = compactUris
   def isWithSourceMaps: Boolean          = sources
   def isWithRawSourceMaps: Boolean       = rawSourceMaps
-  def isAmfJsonLdSerilization: Boolean   = amfJsonLdSerialization
+  def isAmfJsonLdSerialization: Boolean  = amfJsonLdSerialization
   def isValidation: Boolean              = validating
   def renderField(field: Field): Boolean = !filterFields(field)
   def isPrettyPrint: Boolean             = prettyPrint

--- a/shared/src/main/scala/amf/client/remod/amfcore/plugins/parse/AMFParsePlugin.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/plugins/parse/AMFParsePlugin.scala
@@ -7,7 +7,7 @@ import amf.core.errorhandling.ErrorHandler
 import amf.core.model.document.BaseUnit
 import amf.core.parser.{ParserContext, ReferenceHandler}
 
-private[amf] trait AMFParsePlugin extends AMFPlugin[ParsingInfo] {
+trait AMFParsePlugin extends AMFPlugin[ParsingInfo] {
 
 //  def parse(document:Root, ctx:ParserContext): BaseUnit // change parser for AMF context
   def parse(document: Root, ctx: ParserContext, options: ParsingOptions): BaseUnit

--- a/shared/src/main/scala/amf/client/remod/amfcore/plugins/parse/DomainParsingFallback.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/plugins/parse/DomainParsingFallback.scala
@@ -4,7 +4,7 @@ import amf.core.exception.UnsupportedVendorException
 import amf.core.model.document.{BaseUnit, ExternalFragment}
 import amf.core.model.domain.ExternalDomainElement
 
-private[amf] trait DomainParsingFallback {
+trait DomainParsingFallback {
 
   def chooseFallback(element: ParsingInfo, availablePlugins: Seq[AMFParsePlugin]): BaseUnit
 }
@@ -20,9 +20,9 @@ object ExternalFragmentDomainFallback extends DomainParsingFallback {
           .withId(document.location)
           .withLocation(document.location)
           .withEncodes(
-            ExternalDomainElement()
-              .withRaw(document.raw)
-              .withMediaType(document.mediatype))
+              ExternalDomainElement()
+                .withRaw(document.raw)
+                .withMediaType(document.mediatype))
     }
 
   }

--- a/shared/src/main/scala/amf/client/remod/amfcore/plugins/render/AMFRenderPlugin.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/plugins/render/AMFRenderPlugin.scala
@@ -7,17 +7,20 @@ import amf.core.errorhandling.ErrorHandler
 import amf.core.model.document.BaseUnit
 import org.yaml.builder.DocBuilder
 
-private[amf] trait AMFRenderPlugin extends AMFPlugin[RenderInfo] {
-  def emit[T](unit: BaseUnit, builder: DocBuilder[T], renderOptions: RenderOptions, errorHandler: ErrorHandler): Boolean
+trait AMFRenderPlugin extends AMFPlugin[RenderInfo] {
+  def emit[T](unit: BaseUnit,
+              builder: DocBuilder[T],
+              renderOptions: RenderOptions,
+              errorHandler: ErrorHandler): Boolean
 }
 
-private[amf] case class AMFRenderPluginAdapter(plugin: AMFDocumentPlugin) extends AMFRenderPlugin {
+case class AMFRenderPluginAdapter(plugin: AMFDocumentPlugin) extends AMFRenderPlugin {
 
-  override def emit[T](unit: BaseUnit, builder: DocBuilder[T], renderOptions: RenderOptions, errorHandler: ErrorHandler): Boolean =
-    plugin.emit(unit,
-                builder,
-                renderOptions,
-                errorHandler)
+  override def emit[T](unit: BaseUnit,
+                       builder: DocBuilder[T],
+                       renderOptions: RenderOptions,
+                       errorHandler: ErrorHandler): Boolean =
+    plugin.emit(unit, builder, renderOptions, errorHandler)
 
   override val id: String = plugin.ID
 

--- a/shared/src/main/scala/amf/client/remod/amfcore/plugins/render/AMFRenderPlugin.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/plugins/render/AMFRenderPlugin.scala
@@ -14,7 +14,7 @@ trait AMFRenderPlugin extends AMFPlugin[RenderInfo] {
               errorHandler: ErrorHandler): Boolean
 }
 
-case class AMFRenderPluginAdapter(plugin: AMFDocumentPlugin) extends AMFRenderPlugin {
+private[amf] case class AMFRenderPluginAdapter(plugin: AMFDocumentPlugin) extends AMFRenderPlugin {
 
   override def emit[T](unit: BaseUnit,
                        builder: DocBuilder[T],

--- a/shared/src/main/scala/amf/client/remod/amfcore/registry/AMFRegistry.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/registry/AMFRegistry.scala
@@ -6,6 +6,13 @@ import amf.client.remod.amfcore.plugins.parse.{AMFParsePlugin, DomainParsingFall
 import amf.core.resolution.pipelines.TransformationPipeline
 import amf.core.validation.core.ValidationProfile
 
+/**
+  * Registry to store plugins, entities, transformation pipelines and constraint rules
+  * @param plugins {@link amf.client.remod.amfcore.registry.PluginsRegistry}
+  * @param entitiesRegistry {@link amf.client.remod.amfcore.registry.EntitiesRegistry}
+  * @param transformationPipelines a map of {@link amf.core.resolution.pipelines.ResolutionPipeline}s
+  * @param constraintsRules a map of {@link amf.ProfileName} -> {@link amf.core.validation.core.ValidationProfile}
+  */
 private[amf] case class AMFRegistry(plugins: PluginsRegistry,
                                     entitiesRegistry: EntitiesRegistry,
                                     transformationPipelines: Map[String, TransformationPipeline],
@@ -37,5 +44,7 @@ private[amf] case class AMFRegistry(plugins: PluginsRegistry,
 }
 
 object AMFRegistry {
+
+  /** Creates an empty AMF Registry */
   val empty = new AMFRegistry(PluginsRegistry.empty, EntitiesRegistry.empty, Map.empty, Map.empty)
 }

--- a/shared/src/main/scala/amf/client/remod/amfcore/registry/PluginsRegistry.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/registry/PluginsRegistry.scala
@@ -7,6 +7,13 @@ import amf.client.remod.amfcore.plugins.render.AMFRenderPlugin
 import amf.client.remod.amfcore.plugins.validate.AMFValidatePlugin
 import amf.core.model.document.BaseUnit
 
+/**
+  * A registry of plugins
+  * @param parsePlugins a list of {@link amf.client.remod.amfcore.plugins.parse.AMFParsePlugin}
+  * @param validatePlugins a list of {@link amf.client.remod.amfcore.plugins.validate.AMFValidatePlugin}
+  * @param renderPlugins a list of {@link amf.client.remod.amfcore.plugins.render.AMFRenderPlugin}
+  * @param domainParsingFallback {@link amf.client.remod.amfcore.plugins.parse.DomainParsingFallback}
+  */
 case class PluginsRegistry private[amf] (parsePlugins: List[AMFParsePlugin],
                                          validatePlugins: List[AMFValidatePlugin],
                                          renderPlugins: List[AMFRenderPlugin],
@@ -38,5 +45,7 @@ case class PluginsRegistry private[amf] (parsePlugins: List[AMFParsePlugin],
 }
 
 object PluginsRegistry {
+
+  /** Creates an empty PluginsRegistry */
   val empty: PluginsRegistry = PluginsRegistry(Nil, Nil, Nil, ExternalFragmentDomainFallback)
 }


### PR DESCRIPTION
- Add javadoc to most remodularization classes, methods and objects
- Remove the private[amf] modifier on those classes/methods/objects