### PR TITLE
APIMF-2964: define namespace alias plugin in configuration

### DIFF
--- a/shared/src/main/scala/amf/Core.scala
+++ b/shared/src/main/scala/amf/Core.scala
@@ -69,7 +69,5 @@ object Core extends PlatformSecrets {
   def emitShapesGraph(profileName: ProfileName): String =
     Validator.emitShapesGraph(profileName)
 
-  def registerNamespace(alias: String, prefix: String): Boolean = platform.registerNamespace(alias, prefix).isDefined
-
   def registerPlugin(plugin: AMFPlugin): Unit = AMF.registerPlugin(plugin)
 }

--- a/shared/src/main/scala/amf/client/model/document/BaseUnit.scala
+++ b/shared/src/main/scala/amf/client/model/document/BaseUnit.scala
@@ -63,10 +63,10 @@ trait BaseUnit extends AmfObjectWrapper with PlatformSecrets with RdfExportable 
   }
 
   def findById(id: String): ClientOption[DomainElement] =
-    _internal.findById(Namespace.staticAliases.uri(id).iri()).asClient
+    _internal.findById(Namespace.defaultAliases.uri(id).iri()).asClient
 
   def findByType(typeId: String): ClientList[DomainElement] =
-    _internal.findByType(Namespace.staticAliases.expand(typeId).iri()).asClient
+    _internal.findByType(Namespace.defaultAliases.expand(typeId).iri()).asClient
 
   def sourceVendor: ClientOption[Vendor] = _internal.sourceVendor.asClient
 

--- a/shared/src/main/scala/amf/client/plugins/AMFDocumentPlugin.scala
+++ b/shared/src/main/scala/amf/client/plugins/AMFDocumentPlugin.scala
@@ -93,9 +93,5 @@ abstract class AMFDocumentPlugin extends AMFPlugin {
     */
   def canUnparse(unit: BaseUnit): Boolean
 
-  def canGenerateNamespaceAliases(unit: BaseUnit): Boolean = false
-
-  def generateNamespaceAliases(unit: BaseUnit): NamespaceAliases = Namespace.staticAliases
-
   def referenceHandler(eh: ErrorHandler): ReferenceHandler
 }

--- a/shared/src/main/scala/amf/client/remod/amfcore/plugins/namespace/NamespaceAliasesPlugin.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/plugins/namespace/NamespaceAliasesPlugin.scala
@@ -1,0 +1,9 @@
+package amf.client.remod.amfcore.plugins.namespace
+
+import amf.client.remod.amfcore.plugins.AMFPlugin
+import amf.core.model.document.BaseUnit
+import amf.core.vocabulary.NamespaceAliases
+
+trait NamespaceAliasesPlugin extends AMFPlugin[BaseUnit] {
+  def aliases(unit: BaseUnit): NamespaceAliases
+}

--- a/shared/src/main/scala/amf/client/remod/amfcore/plugins/render/RenderConfiguration.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/plugins/render/RenderConfiguration.scala
@@ -2,16 +2,19 @@ package amf.client.remod.amfcore.plugins.render
 
 import amf.client.remod.AMFGraphConfiguration
 import amf.client.remod.amfcore.config.{AMFEventListener, RenderOptions}
+import amf.client.remod.amfcore.plugins.namespace.NamespaceAliasesPlugin
 import amf.core.errorhandling.ErrorHandler
 
 trait RenderConfiguration {
   def renderPlugins: List[AMFRenderPlugin]
+  def namespacePlugins: List[NamespaceAliasesPlugin]
   def renderOptions: RenderOptions
   def errorHandler: ErrorHandler
   def listeners: Set[AMFEventListener]
 }
 
 case class DefaultRenderConfiguration(renderPlugins: List[AMFRenderPlugin],
+                                      namespacePlugins: List[NamespaceAliasesPlugin],
                                       renderOptions: RenderOptions,
                                       errorHandler: ErrorHandler,
                                       listeners: Set[AMFEventListener])
@@ -19,9 +22,12 @@ case class DefaultRenderConfiguration(renderPlugins: List[AMFRenderPlugin],
 
 object DefaultRenderConfiguration {
   def apply(env: AMFGraphConfiguration): RenderConfiguration = {
-    DefaultRenderConfiguration(env.registry.plugins.renderPlugins,
-                               env.options.renderOptions,
-                               env.errorHandlerProvider.errorHandler(),
-                               env.listeners)
+    DefaultRenderConfiguration(
+        env.registry.plugins.renderPlugins,
+        env.registry.plugins.namespacePlugins,
+        env.options.renderOptions,
+        env.errorHandlerProvider.errorHandler(),
+        env.listeners
+    )
   }
 }

--- a/shared/src/main/scala/amf/client/remod/amfcore/registry/PluginsRegistry.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/registry/PluginsRegistry.scala
@@ -2,6 +2,7 @@ package amf.client.remod.amfcore.registry
 
 import amf.ProfileName
 import amf.client.remod.amfcore.plugins.AMFPlugin
+import amf.client.remod.amfcore.plugins.namespace.NamespaceAliasesPlugin
 import amf.client.remod.amfcore.plugins.parse.{AMFParsePlugin, DomainParsingFallback, ExternalFragmentDomainFallback}
 import amf.client.remod.amfcore.plugins.render.AMFRenderPlugin
 import amf.client.remod.amfcore.plugins.validate.AMFValidatePlugin
@@ -17,6 +18,7 @@ import amf.core.model.document.BaseUnit
 case class PluginsRegistry private[amf] (parsePlugins: List[AMFParsePlugin],
                                          validatePlugins: List[AMFValidatePlugin],
                                          renderPlugins: List[AMFRenderPlugin],
+                                         namespacePlugins: List[NamespaceAliasesPlugin],
                                          domainParsingFallback: DomainParsingFallback) {
 
   lazy val allPlugins: List[AMFPlugin[_]] = parsePlugins ++ validatePlugins ++ renderPlugins
@@ -29,6 +31,8 @@ case class PluginsRegistry private[amf] (parsePlugins: List[AMFParsePlugin],
         copy(validatePlugins = validatePlugins :+ v)
       case r: AMFRenderPlugin if !renderPlugins.exists(_.id == r.id) =>
         copy(renderPlugins = renderPlugins :+ r)
+      case r: NamespaceAliasesPlugin if !namespacePlugins.exists(_.id == r.id) =>
+        copy(namespacePlugins = namespacePlugins :+ r)
       case _ => this
     }
   }
@@ -38,14 +42,17 @@ case class PluginsRegistry private[amf] (parsePlugins: List[AMFParsePlugin],
   }
 
   def removePlugin(id: String): PluginsRegistry =
-    copy(parsePlugins = parsePlugins.filterNot(_.id == id),
-         validatePlugins = validatePlugins.filterNot(_.id == id),
-         renderPlugins = renderPlugins.filterNot(_.id == id))
+    copy(
+        parsePlugins = parsePlugins.filterNot(_.id == id),
+        validatePlugins = validatePlugins.filterNot(_.id == id),
+        renderPlugins = renderPlugins.filterNot(_.id == id),
+        namespacePlugins = namespacePlugins.filterNot(_.id == id)
+    )
 
 }
 
 object PluginsRegistry {
 
   /** Creates an empty PluginsRegistry */
-  val empty: PluginsRegistry = PluginsRegistry(Nil, Nil, Nil, ExternalFragmentDomainFallback)
+  val empty: PluginsRegistry = PluginsRegistry(Nil, Nil, Nil, Nil, ExternalFragmentDomainFallback)
 }

--- a/shared/src/main/scala/amf/core/AMFSerializer.scala
+++ b/shared/src/main/scala/amf/core/AMFSerializer.scala
@@ -94,7 +94,7 @@ class AMFSerializer(unit: BaseUnit, mediaType: String, vendor: String, config: R
     config.namespacePlugins.sorted
       .find(_.applies(unit))
       .map(_.aliases(unit))
-      .getOrElse(Namespace.staticAliases)
+      .getOrElse(Namespace.defaultAliases)
 
   /** Print ast to writer. */
   def renderToWriter[W: Output](writer: W)(implicit executor: ExecutionContext): Future[Unit] = Future(render(writer))

--- a/shared/src/main/scala/amf/core/AMFSerializer.scala
+++ b/shared/src/main/scala/amf/core/AMFSerializer.scala
@@ -22,7 +22,7 @@ import amf.core.rdf.RdfModelDocument
 import amf.core.registries.AMFPluginsRegistry
 import amf.core.remote.{Platform, Vendor}
 import amf.core.services.RuntimeSerializer
-import amf.core.vocabulary.Namespace
+import amf.core.vocabulary.{Namespace, NamespaceAliases}
 import amf.plugins.document.graph.AMFGraphPlugin.platform
 import amf.plugins.document.graph.{
   EmbeddedForm,
@@ -90,12 +90,11 @@ class AMFSerializer(unit: BaseUnit, mediaType: String, vendor: String, config: R
     }
   }
 
-  private def generateNamespaceAliasesFromPlugins[T] = {
-    AMFPluginsRegistry.documentPlugins
-      .find(_.canGenerateNamespaceAliases(unit))
-      .map(_.generateNamespaceAliases(unit))
+  private def generateNamespaceAliasesFromPlugins: NamespaceAliases =
+    config.namespacePlugins.sorted
+      .find(_.applies(unit))
+      .map(_.aliases(unit))
       .getOrElse(Namespace.staticAliases)
-  }
 
   /** Print ast to writer. */
   def renderToWriter[W: Output](writer: W)(implicit executor: ExecutionContext): Future[Unit] = Future(render(writer))

--- a/shared/src/main/scala/amf/core/model/domain/Graph.scala
+++ b/shared/src/main/scala/amf/core/model/domain/Graph.scala
@@ -19,7 +19,7 @@ case class Graph(e: DomainElement) {
 
   def scalarByProperty(propertyId: String): Seq[Any] = {
     e.fields.fields().find { f: FieldEntry =>
-      f.field.value.iri() == Namespace.staticAliases.uri(propertyId).iri()
+      f.field.value.iri() == Namespace.defaultAliases.uri(propertyId).iri()
     } match {
       case Some(fieldEntry) =>
         fieldEntry.element match {
@@ -33,7 +33,7 @@ case class Graph(e: DomainElement) {
 
   def getObjectByPropertyId(propertyId: String): Seq[DomainElement] = {
     e.fields.fields().find { f: FieldEntry =>
-      f.field.value.iri() == Namespace.staticAliases.uri(propertyId).iri()
+      f.field.value.iri() == Namespace.defaultAliases.uri(propertyId).iri()
     } match {
       case Some(fieldEntry) =>
         fieldEntry.element match {
@@ -46,9 +46,10 @@ case class Graph(e: DomainElement) {
     }
   }
 
-  def containsField(f:Field): Boolean = properties().contains(f.toString)
+  def containsField(f: Field): Boolean = properties().contains(f.toString)
 
-  def annotationsForValue(f:Field): Annotations = e.fields.getValueAsOption(f).map(_.annotations).getOrElse(Annotations())
+  def annotationsForValue(f: Field): Annotations =
+    e.fields.getValueAsOption(f).map(_.annotations).getOrElse(Annotations())
 
   def patchField(patchField: Field, patchValue: Value): Unit = {
     e.set(patchField, patchValue.value, annotationsForValue(patchField))

--- a/shared/src/main/scala/amf/core/remote/Platform.scala
+++ b/shared/src/main/scala/amf/core/remote/Platform.scala
@@ -175,10 +175,6 @@ trait Platform extends FileMediaType {
   /** normalize path method for file fetching in amf compiler */
   def normalizePath(url: String): String
 
-  /** Register an alias for a namespace */
-  def registerNamespace(alias: String, prefix: String): Option[Namespace] =
-    Namespace.staticAliases.registerNamespace(alias, prefix)
-
   // Optional RdfFramework
   var rdfFramework: Option[RdfFramework] = None
 

--- a/shared/src/main/scala/amf/core/validation/EffectiveValidations.scala
+++ b/shared/src/main/scala/amf/core/validation/EffectiveValidations.scala
@@ -59,7 +59,7 @@ class EffectiveValidations(val effective: mutable.HashMap[String, ValidationSpec
 
   private def toIri(id: String): ValidationIri = {
     if (!isIri(id)) {
-      Namespace.staticAliases.expand(id.replace(".", ":")).iri()
+      Namespace.defaultAliases.expand(id.replace(".", ":")).iri()
     } else {
       id
     }

--- a/shared/src/main/scala/amf/core/validation/core/ValidationSpecification.scala
+++ b/shared/src/main/scala/amf/core/validation/core/ValidationSpecification.scala
@@ -149,7 +149,7 @@ case class ValidationSpecification(name: String,
     if (name.startsWith("http://") || name.startsWith("https://") || name.startsWith("file:")) {
       name
     } else {
-      Namespace.staticAliases.expand(name).iri() match {
+      Namespace.defaultAliases.expand(name).iri() match {
         case s if s.startsWith("http://") || s.startsWith("https://") || s.startsWith("file:") => s
         case s                                                                                 => (Namespace.Data + s).iri()
       }
@@ -182,9 +182,9 @@ object ValidationSpecification {
 
 object ShaclSeverityUris {
 
-  private val SHACL_VIOLATION: String = Namespace.staticAliases.expand("sh:Violation").iri()
-  private val SHACL_WARNING: String = Namespace.staticAliases.expand("sh:Warning").iri()
-  private val SHACL_INFO: String = Namespace.staticAliases.expand("sh:Info").iri()
+  private val SHACL_VIOLATION: String = Namespace.defaultAliases.expand("sh:Violation").iri()
+  private val SHACL_WARNING: String = Namespace.defaultAliases.expand("sh:Warning").iri()
+  private val SHACL_INFO: String = Namespace.defaultAliases.expand("sh:Info").iri()
 
   private lazy val shaclSeverities = Map(
     VIOLATION -> SHACL_VIOLATION,

--- a/shared/src/main/scala/amf/core/vocabulary/Namespace.scala
+++ b/shared/src/main/scala/amf/core/vocabulary/Namespace.scala
@@ -72,7 +72,7 @@ object Namespace {
     val amlAnyNode: ValueType = Namespace.Meta + "anyNode"
   }
 
-  val staticAliases: NamespaceAliases = NamespaceAliases()
+  val defaultAliases: NamespaceAliases = NamespaceAliases()
 }
 
 case class NamespaceAliases private (ns: Map[Aliases.Alias, Namespace]) {

--- a/shared/src/main/scala/amf/plugins/document/graph/emitter/GraphEmitterContext.scala
+++ b/shared/src/main/scala/amf/plugins/document/graph/emitter/GraphEmitterContext.scala
@@ -15,7 +15,7 @@ class GraphEmitterContext(val prefixes: mutable.Map[String, String],
                           val options: RenderOptions,
                           var emittingDeclarations: Boolean = false,
                           var emittingReferences: Boolean = false,
-                          val namespaceAliases: NamespaceAliases = Namespace.staticAliases) {
+                          val namespaceAliases: NamespaceAliases = Namespace.defaultAliases) {
   var counter: Int = 1
 
   private val declarations: mutable.LinkedHashSet[AmfElement] = mutable.LinkedHashSet.empty
@@ -99,8 +99,7 @@ class GraphEmitterContext(val prefixes: mutable.Map[String, String],
       if (uri.startsWith(base)) uri.replace(base, "")
       else if (uri.startsWith(baseParent)) uri.replace(s"$baseParent/", "./")
       else uri
-    }
-    else uri
+    } else uri
   }
 
   private def baseParent: String = {
@@ -113,18 +112,15 @@ class GraphEmitterContext(val prefixes: mutable.Map[String, String],
       base = if (location.replace("://", "").contains("/")) {
         val basePre = if (location.contains("#")) {
           location.split("#").head
-        }
-        else {
+        } else {
           location
         }
         val parts = basePre.split("/").dropRight(1)
         parts.mkString("/")
-      }
-      else {
+      } else {
         location.split("#").head
       }
-    }
-    else {
+    } else {
       base = ""
     }
   }
@@ -142,7 +138,7 @@ class GraphEmitterContext(val prefixes: mutable.Map[String, String],
 }
 
 object GraphEmitterContext {
-  def apply(unit: BaseUnit, options: RenderOptions, namespaceAliases: NamespaceAliases = Namespace.staticAliases) =
+  def apply(unit: BaseUnit, options: RenderOptions, namespaceAliases: NamespaceAliases = Namespace.defaultAliases) =
     new GraphEmitterContext(mutable.Map(), unit.id, options, namespaceAliases = namespaceAliases)
 }
 
@@ -150,12 +146,12 @@ class FlattenedGraphEmitterContext(prefixes: mutable.Map[String, String],
                                    base: String,
                                    options: RenderOptions,
                                    emittingDeclarations: Boolean = false,
-                                   namespaceAliases: NamespaceAliases = Namespace.staticAliases)
+                                   namespaceAliases: NamespaceAliases = Namespace.defaultAliases)
     extends GraphEmitterContext(prefixes, base, options, emittingDeclarations, namespaceAliases = namespaceAliases) {
   override def canGenerateLink(e: AmfElement): Boolean = false
 }
 
 object FlattenedGraphEmitterContext {
-  def apply(unit: BaseUnit, options: RenderOptions, namespaceAliases: NamespaceAliases = Namespace.staticAliases) =
+  def apply(unit: BaseUnit, options: RenderOptions, namespaceAliases: NamespaceAliases = Namespace.defaultAliases) =
     new FlattenedGraphEmitterContext(mutable.Map(), unit.id, options, namespaceAliases = namespaceAliases)
 }

--- a/shared/src/main/scala/amf/plugins/document/graph/parser/EmbeddedGraphParser.scala
+++ b/shared/src/main/scala/amf/plugins/document/graph/parser/EmbeddedGraphParser.scala
@@ -112,8 +112,8 @@ class EmbeddedGraphParser()(implicit val ctx: GraphParserContext) extends GraphP
                 val modelFields = model match {
                   case shapeModel: ShapeModel =>
                     shapeModel.fields ++ Seq(
-                      ShapeModel.CustomShapePropertyDefinitions,
-                      ShapeModel.CustomShapeProperties
+                        ShapeModel.CustomShapePropertyDefinitions,
+                        ShapeModel.CustomShapeProperties
                     )
                   case _ => model.fields
                 }
@@ -222,7 +222,7 @@ class EmbeddedGraphParser()(implicit val ctx: GraphParserContext) extends GraphP
               val obj       = entry.value.as[YMap]
 
               parseScalarProperty(obj, DomainExtensionModel.Name)
-                .map(extension.set(DomainExtensionModel.Name,_))
+                .map(extension.set(DomainExtensionModel.Name, _))
               parseScalarProperty(obj, DomainExtensionModel.Element)
                 .map(extension.withElement)
 
@@ -369,8 +369,8 @@ object EmbeddedGraphParser {
         val keys                                  = Seq("encodes", "declares", "references").map(toDocumentNamespace)
         val types                                 = Seq("Document", "Fragment", "Module", "Unit").map(toDocumentNamespace)
 
-        val acceptedKeys  = keys ++ keys.map(Namespace.staticAliases.compact)
-        val acceptedTypes = types ++ types.map(Namespace.staticAliases.compact)
+        val acceptedKeys  = keys ++ keys.map(Namespace.defaultAliases.compact)
+        val acceptedTypes = types ++ types.map(Namespace.defaultAliases.compact)
         acceptedKeys.exists(m.key(_).isDefined) ||
         m.key(JsonLdKeywords.Type).exists { typesEntry =>
           val retrievedTypes = typesEntry.value.asOption[YSequence].map(stringNodesFrom)


### PR DESCRIPTION
- NamespaceAlias used for rendering jsonld are generated with a new plugin.
- NamespaceAlias class is made immutable, legacy staticAliases cannot be modified making "registerNamespace" method imposible.