### PR TITLE
APIMF-2896: add scaladoc to remod/exported files

### DIFF
--- a/shared/src/main/scala/amf/client/exported/AMFGraphClient.scala
+++ b/shared/src/main/scala/amf/client/exported/AMFGraphClient.scala
@@ -3,11 +3,16 @@ package amf.client.exported
 import amf.ProfileName
 import amf.client.convert.CoreClientConverters._
 import amf.client.model.document.BaseUnit
-import amf.client.validate.AMFValidationReport
 import amf.client.remod.{AMFGraphClient => InternalAMFGraphClient}
+import amf.client.validate.AMFValidationReport
+
 import scala.concurrent.ExecutionContext
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 
+/**
+  * Contains common AMF graph operations.
+  * Base client for <code>AMLClient</code> and <code>AMFClient</code>.
+  */
 @JSExportAll
 class AMFGraphClient private[amf] (private val _internal: InternalAMFGraphClient) {
 
@@ -20,18 +25,80 @@ class AMFGraphClient private[amf] (private val _internal: InternalAMFGraphClient
 
   def getConfiguration: AMFGraphConfiguration = _internal.getConfiguration
 
-  def parse(url: String): ClientFuture[AMFResult]                    = _internal.parse(url).asClient
+  /**
+    * Asynchronously generate a BaseUnit from the unit located in the given url.
+    * @param url Location of the file to parse
+    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    */
+  def parse(url: String): ClientFuture[AMFResult] = _internal.parse(url).asClient
+
+  /**
+    * Asynchronously generate a BaseUnit from the unit located in the given url.
+    * @param url Location of the file to parse
+    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
+    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    */
   def parse(url: String, mediaType: String): ClientFuture[AMFResult] = _internal.parse(url, mediaType).asClient
-  def parseContent(content: String): ClientFuture[AMFResult]         = _internal.parseContent(content).asClient
+
+  /**
+    * Asynchronously generate a BaseUnit from a given string.
+    * @param content The unit as a string
+    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    */
+  def parseContent(content: String): ClientFuture[AMFResult] = _internal.parseContent(content).asClient
+
+  /**
+    * Asynchronously generate a BaseUnit from a given string.
+    * @param content The unit as a string
+    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
+    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @example <code>parseContent("example content", "application/oas20+yaml")</code>
+    */
   def parseContent(content: String, mediaType: String): ClientFuture[AMFResult] =
     _internal.parseContent(content, mediaType).asClient
 
-  def transform(bu: BaseUnit): AMFResult                       = _internal.transform(bu)
+  /**
+    * Transforms a [[amf.client.model.document.BaseUnit]] with the default configuration
+    * @param bu [[amf.client.model.document.BaseUnit]] to transform
+    * @return An [[amf.client.exported.AMFResult]] with the transformed BaseUnit and it's report
+    */
+  def transform(bu: BaseUnit): AMFResult = _internal.transform(bu)
+
+  /**
+    * Transforms a [[amf.client.model.document.BaseUnit]] with a specific pipeline
+    * @param bu [[amf.client.model.document.BaseUnit]] to transform
+    * @param pipelineName name of any custom or [[AMFGraphConfiguration.predefined predefined]] pipeline
+    * @return An [[amf.client.exported.AMFResult]] with the transformed BaseUnit and it's report
+    */
   def transform(bu: BaseUnit, pipelineName: String): AMFResult = _internal.transform(bu, pipelineName)
 
-  def render(bu: BaseUnit): String                    = _internal.render(bu)
+  /**
+    * Render a [[amf.client.model.document.BaseUnit]] to its default type
+    * @param bu [[amf.client.model.document.BaseUnit]] to be rendered
+    * @return the unit rendered
+    */
+  def render(bu: BaseUnit): String = _internal.render(bu)
+
+  /**
+    * Render a [[amf.client.model.document.BaseUnit]] to a certain mediaType
+    * @param bu [[amf.client.model.document.BaseUnit]] to be rendered
+    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
+    * @return the unit rendered
+    */
   def render(bu: BaseUnit, mediaType: String): String = _internal.render(bu, mediaType)
 
-  def validate(bu: BaseUnit): AMFValidationReport                           = _internal.validate(bu)
+  /**
+    * Validate a [[amf.client.model.document.BaseUnit]] with its default validation profile
+    * @param bu [[amf.client.model.document.BaseUnit]] to validate
+    * @return an [[amf.client.validate.AMFValidationReport]]
+    */
+  def validate(bu: BaseUnit): AMFValidationReport = _internal.validate(bu)
+
+  /**
+    * Validate a [[amf.client.model.document.BaseUnit]] with a specific validation profile
+    * @param bu [[amf.client.model.document.BaseUnit]] to validate
+    * @param profileName the [[amf.ProfileName]] of the desired validation profile
+    * @return an [[amf.client.validate.AMFValidationReport]]
+    */
   def validate(bu: BaseUnit, profileName: ProfileName): AMFValidationReport = _internal.validate(bu, profileName)
 }

--- a/shared/src/main/scala/amf/client/exported/AMFGraphClient.scala
+++ b/shared/src/main/scala/amf/client/exported/AMFGraphClient.scala
@@ -26,79 +26,81 @@ class AMFGraphClient private[amf] (private val _internal: InternalAMFGraphClient
   def getConfiguration: AMFGraphConfiguration = _internal.getConfiguration
 
   /**
-    * Asynchronously generate a BaseUnit from the unit located in the given url.
+    * Asynchronously generate a BaseUnit from the content located in the given url.
     * @param url Location of the file to parse
-    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parse(url: String): ClientFuture[AMFResult] = _internal.parse(url).asClient
 
   /**
-    * Asynchronously generate a BaseUnit from the unit located in the given url.
+    * Asynchronously generate a BaseUnit from the content located in the given url.
     * @param url Location of the file to parse
-    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
-    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parse(url: String, mediaType: String): ClientFuture[AMFResult] = _internal.parse(url, mediaType).asClient
 
   /**
     * Asynchronously generate a BaseUnit from a given string.
-    * @param content The unit as a string
-    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param content The content as a string
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parseContent(content: String): ClientFuture[AMFResult] = _internal.parseContent(content).asClient
 
   /**
     * Asynchronously generate a BaseUnit from a given string.
-    * @param content The unit as a string
-    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
-    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
-    * @example <code>parseContent("example content", "application/oas20+yaml")</code>
+    * @param content The content as a string
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parseContent(content: String, mediaType: String): ClientFuture[AMFResult] =
     _internal.parseContent(content, mediaType).asClient
 
   /**
-    * Transforms a [[amf.client.model.document.BaseUnit]] with the default configuration
-    * @param bu [[amf.client.model.document.BaseUnit]] to transform
-    * @return An [[amf.client.exported.AMFResult]] with the transformed BaseUnit and it's report
+    * Transforms a [[BaseUnit]] with the default configuration
+    * @param bu [[BaseUnit]] to transform
+    * @return An [[AMFResult]] with the transformed BaseUnit and it's report
     */
   def transform(bu: BaseUnit): AMFResult = _internal.transform(bu)
 
   /**
-    * Transforms a [[amf.client.model.document.BaseUnit]] with a specific pipeline
-    * @param bu [[amf.client.model.document.BaseUnit]] to transform
+    * Transforms a [[BaseUnit]] with a specific pipeline
+    * @param bu [[BaseUnit]] to transform
     * @param pipelineName name of any custom or [[AMFGraphConfiguration.predefined predefined]] pipeline
-    * @return An [[amf.client.exported.AMFResult]] with the transformed BaseUnit and it's report
+    * @return An [[AMFResult]] with the transformed BaseUnit and it's report
     */
   def transform(bu: BaseUnit, pipelineName: String): AMFResult = _internal.transform(bu, pipelineName)
 
   /**
-    * Render a [[amf.client.model.document.BaseUnit]] to its default type
-    * @param bu [[amf.client.model.document.BaseUnit]] to be rendered
-    * @return the unit rendered
+    * Render a [[BaseUnit]] to its default type
+    * @param bu [[BaseUnit]] to be rendered
+    * @return The content rendered
     */
   def render(bu: BaseUnit): String = _internal.render(bu)
 
   /**
-    * Render a [[amf.client.model.document.BaseUnit]] to a certain mediaType
-    * @param bu [[amf.client.model.document.BaseUnit]] to be rendered
-    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
-    * @return the unit rendered
+    * Render a [[BaseUnit]] to a certain mediaType
+    * @param bu [[BaseUnit]] to be rendered
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @return The content rendered
     */
   def render(bu: BaseUnit, mediaType: String): String = _internal.render(bu, mediaType)
 
   /**
-    * Validate a [[amf.client.model.document.BaseUnit]] with its default validation profile
-    * @param bu [[amf.client.model.document.BaseUnit]] to validate
-    * @return an [[amf.client.validate.AMFValidationReport]]
+    * Validate a [[BaseUnit]] with its default validation profile name
+    * @param bu [[BaseUnit]] to validate
+    * @return an [[AMFValidationReport]]
     */
   def validate(bu: BaseUnit): AMFValidationReport = _internal.validate(bu)
 
   /**
-    * Validate a [[amf.client.model.document.BaseUnit]] with a specific validation profile
-    * @param bu [[amf.client.model.document.BaseUnit]] to validate
+    * Validate a [[BaseUnit]] with a specific validation profile name
+    * @param bu [[BaseUnit]] to validate
     * @param profileName the [[amf.ProfileName]] of the desired validation profile
-    * @return an [[amf.client.validate.AMFValidationReport]]
+    * @return an [[AMFValidationReport]]
     */
   def validate(bu: BaseUnit, profileName: ProfileName): AMFValidationReport = _internal.validate(bu, profileName)
 }

--- a/shared/src/main/scala/amf/client/exported/AMFGraphConfiguration.scala
+++ b/shared/src/main/scala/amf/client/exported/AMFGraphConfiguration.scala
@@ -1,17 +1,18 @@
 package amf.client.exported
 
-import amf.client.remod.{AMFGraphConfiguration => InternalGraphConfiguration}
-import amf.client.resolve.ClientErrorHandlerConverter._
 import amf.client.convert.CoreClientConverters._
 import amf.client.convert.TransformationPipelineConverter._
 import amf.client.exported.config.{AMFEventListener, AMFLogger, ParsingOptions, RenderOptions}
 import amf.client.exported.transform.TransformationPipeline
 import amf.client.reference.UnitCache
+import amf.client.remod.{AMFGraphConfiguration => InternalGraphConfiguration}
+import amf.client.resolve.ClientErrorHandlerConverter._
 import amf.client.resource.ResourceLoader
 
 import scala.concurrent.ExecutionContext
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 
+/** Base AMF configuration object */
 @JSExportAll
 class AMFGraphConfiguration private[amf] (private[amf] val _internal: InternalGraphConfiguration) {
   private implicit val ec: ExecutionContext = _internal.getExecutionContext
@@ -57,13 +58,11 @@ object AMFGraphConfiguration {
 
   /**
     * Predefined AMF core environment with:
-    * <ul>
-    *   <li>AMF Resolvers predefined `amf.client.remod.amfcore.config.AMFResolvers.predefined`</li>
-    *   <li>Default error handler provider that will create a {@link amf.client.parse.DefaultParserErrorHandler}</li>
-    *   <li>Empty `amf.client.remod.amfcore.registry.AMFRegistry`</li>
-    *   <li>MutedLogger: `amf.client.remod.amfcore.config.MutedLogger`</li>
-    *   <li>Without Any listener</li>
-    * </ul>
+    *   - AMF Resolvers [[amf.client.remod.amfcore.config.AMFResolvers.predefined predefined]]
+    *   - Default error handler provider that will create a [[amf.client.parse.DefaultParserErrorHandler]]
+    *   - Empty [[amf.client.remod.amfcore.registry.AMFRegistry]]
+    *   - MutedLogger: [[amf.client.exported.config.MutedLogger]]
+    *   - Without Any listener
     */
   def predefined(): AMFGraphConfiguration = InternalGraphConfiguration.predefined()
 }

--- a/shared/src/main/scala/amf/client/exported/AMFParser.scala
+++ b/shared/src/main/scala/amf/client/exported/AMFParser.scala
@@ -11,25 +11,51 @@ import scala.concurrent.ExecutionContext
 @JSExportAll
 object AMFParser {
 
-  def parse(url: String, env: AMFGraphConfiguration): ClientFuture[AMFResult] = {
-    implicit val context: ExecutionContext = env._internal.getExecutionContext
-    InternalAMFParser.parse(url, env).asClient
+  /**
+    * Asynchronously generate a BaseUnit from the unit located in the given url.
+    * @param url Location of the api
+    * @param configuration [[amf.client.exported.AMFGraphConfiguration]]
+    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
+    */
+  def parse(url: String, configuration: AMFGraphConfiguration): ClientFuture[AMFResult] = {
+    implicit val context: ExecutionContext = configuration._internal.getExecutionContext
+    InternalAMFParser.parse(url, configuration).asClient
   }
 
-  def parse(url: String, mediaType: String, env: AMFGraphConfiguration): ClientFuture[AMFResult] = {
-    implicit val context: ExecutionContext = env._internal.getExecutionContext
-    InternalAMFParser.parse(url, mediaType, env).asClient
+  /**
+    * Asynchronously generate a BaseUnit from the unit located in the given url.
+    * @param url Location of the api
+    * @param mediaType The type of the file to parse
+    * @param configuration [[amf.client.exported.AMFGraphConfiguration]]
+    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
+    */
+  def parse(url: String, mediaType: String, configuration: AMFGraphConfiguration): ClientFuture[AMFResult] = {
+    implicit val context: ExecutionContext = configuration._internal.getExecutionContext
+    InternalAMFParser.parse(url, mediaType, configuration).asClient
   }
 
-  def parseContent(content: String, env: AMFGraphConfiguration): ClientFuture[AMFResult] = {
-    implicit val context: ExecutionContext = env._internal.getExecutionContext
-    InternalAMFParser.parseContent(content, env).asClient
+  /**
+    * Asynchronously generate a BaseUnit from a given string.
+    * @param content The unit to parse as a string
+    * @param configuration [[amf.client.exported.AMFGraphConfiguration]]
+    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
+    */
+  def parseContent(content: String, configuration: AMFGraphConfiguration): ClientFuture[AMFResult] = {
+    implicit val context: ExecutionContext = configuration._internal.getExecutionContext
+    InternalAMFParser.parseContent(content, configuration).asClient
   }
 
-  def parseContent(content: String, mediaType: String, env: AMFGraphConfiguration): ClientFuture[AMFResult] = {
-    implicit val context: ExecutionContext = env._internal.getExecutionContext
-    InternalAMFParser.parseContent(content, mediaType, env).asClient
+  /**
+    * Asynchronously generate a BaseUnit from a given string.
+    * @param content The unit as a string
+    * @param mediaType The type of the file to parse
+    * @param configuration [[amf.client.exported.AMFGraphConfiguration]]
+    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
+    */
+  def parseContent(content: String, mediaType: String, configuration: AMFGraphConfiguration): ClientFuture[AMFResult] = {
+    implicit val context: ExecutionContext = configuration._internal.getExecutionContext
+    InternalAMFParser.parseContent(content, mediaType, configuration).asClient
   }
 
-  // TODO: content and url? no usage in mulesoft org so this can be ingored.
+  // TODO: content and url? no usage in mulesoft org so this can be ignored.
 }

--- a/shared/src/main/scala/amf/client/exported/AMFParser.scala
+++ b/shared/src/main/scala/amf/client/exported/AMFParser.scala
@@ -14,8 +14,8 @@ object AMFParser {
   /**
     * Asynchronously generate a BaseUnit from the unit located in the given url.
     * @param url Location of the api
-    * @param configuration [[amf.client.exported.AMFGraphConfiguration]]
-    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param configuration [[AMFGraphConfiguration]]
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parse(url: String, configuration: AMFGraphConfiguration): ClientFuture[AMFResult] = {
     implicit val context: ExecutionContext = configuration._internal.getExecutionContext
@@ -25,9 +25,10 @@ object AMFParser {
   /**
     * Asynchronously generate a BaseUnit from the unit located in the given url.
     * @param url Location of the api
-    * @param mediaType The type of the file to parse
-    * @param configuration [[amf.client.exported.AMFGraphConfiguration]]
-    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @param configuration [[AMFGraphConfiguration]]
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parse(url: String, mediaType: String, configuration: AMFGraphConfiguration): ClientFuture[AMFResult] = {
     implicit val context: ExecutionContext = configuration._internal.getExecutionContext
@@ -37,8 +38,8 @@ object AMFParser {
   /**
     * Asynchronously generate a BaseUnit from a given string.
     * @param content The unit to parse as a string
-    * @param configuration [[amf.client.exported.AMFGraphConfiguration]]
-    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param configuration [[AMFGraphConfiguration]]
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parseContent(content: String, configuration: AMFGraphConfiguration): ClientFuture[AMFResult] = {
     implicit val context: ExecutionContext = configuration._internal.getExecutionContext
@@ -48,9 +49,10 @@ object AMFParser {
   /**
     * Asynchronously generate a BaseUnit from a given string.
     * @param content The unit as a string
-    * @param mediaType The type of the file to parse
-    * @param configuration [[amf.client.exported.AMFGraphConfiguration]]
-    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @param configuration [[AMFGraphConfiguration]]
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parseContent(content: String, mediaType: String, configuration: AMFGraphConfiguration): ClientFuture[AMFResult] = {
     implicit val context: ExecutionContext = configuration._internal.getExecutionContext

--- a/shared/src/main/scala/amf/client/exported/AMFRenderer.scala
+++ b/shared/src/main/scala/amf/client/exported/AMFRenderer.scala
@@ -10,9 +10,10 @@ import amf.client.convert.CoreClientConverters._
 object AMFRenderer {
   // TODO: return AMFRenderResult?
 
-  def render(bu: BaseUnit, env: AMFGraphConfiguration): String = InternalAMFRenderer.render(bu, env)
+  def render(bu: BaseUnit, configuration: AMFGraphConfiguration): String =
+    InternalAMFRenderer.render(bu, configuration)
 
-  def render(bu: BaseUnit, mediaType: String, env: AMFGraphConfiguration): String =
-    InternalAMFRenderer.render(bu, mediaType, env)
+  def render(bu: BaseUnit, mediaType: String, configuration: AMFGraphConfiguration): String =
+    InternalAMFRenderer.render(bu, mediaType, configuration)
 
 }

--- a/shared/src/main/scala/amf/client/exported/AMFResult.scala
+++ b/shared/src/main/scala/amf/client/exported/AMFResult.scala
@@ -13,12 +13,12 @@ case class AMFResult(private[amf] val _internal: InternalAMFResult) {
   def conforms: Boolean = _internal.conforms
 
   /**
-    * @return result the resultant {@link amf.client.validate.AMFValidationReport} of the BaseUnit
+    * @return The resultant [[amf.client.validate.AMFValidationReport]] of the BaseUnit
     */
   def validationResult: AMFValidationReport = _internal.result
 
   /**
-    * @return baseUnit {@link amf.client.model.document.BaseUnit} returned from AMF parse or transform
+    * @return [[amf.client.model.document.BaseUnit]] returned from AMF parse or transform
     */
   def baseUnit: BaseUnit = _internal.bu
 }

--- a/shared/src/main/scala/amf/client/exported/AMFResult.scala
+++ b/shared/src/main/scala/amf/client/exported/AMFResult.scala
@@ -13,12 +13,14 @@ case class AMFResult(private[amf] val _internal: InternalAMFResult) {
   def conforms: Boolean = _internal.conforms
 
   /**
-    * @return The resultant [[amf.client.validate.AMFValidationReport]] of the BaseUnit
+    * @return The resultant [[AMFValidationReport]] of the BaseUnit
     */
   def validationResult: AMFValidationReport = _internal.result
 
   /**
-    * @return [[amf.client.model.document.BaseUnit]] returned from AMF parse or transform
+    * @return [[BaseUnit]] returned from AMF parse or transform. It can be:
+    *  - A [[BaseUnit]] when parsing/transformation is successful
+    *  - The most complete unit that could be built, and an [[AMFValidationReport]] report with errors/warnings found
     */
   def baseUnit: BaseUnit = _internal.bu
 }

--- a/shared/src/main/scala/amf/client/exported/AMFTransformer.scala
+++ b/shared/src/main/scala/amf/client/exported/AMFTransformer.scala
@@ -9,9 +9,10 @@ import amf.client.convert.CoreClientConverters._
 @JSExportTopLevel("AMFTransformer")
 object AMFTransformer {
 
-  def transform(unit: BaseUnit, conf: AMFGraphConfiguration): AMFResult = InternalAMFTransformer.transform(unit, conf)
+  def transform(unit: BaseUnit, configuration: AMFGraphConfiguration): AMFResult =
+    InternalAMFTransformer.transform(unit, configuration)
 
-  def transform(unit: BaseUnit, pipelineName: String, conf: AMFGraphConfiguration): AMFResult =
-    InternalAMFTransformer.transform(unit, pipelineName, conf)
+  def transform(unit: BaseUnit, pipelineName: String, configuration: AMFGraphConfiguration): AMFResult =
+    InternalAMFTransformer.transform(unit, pipelineName, configuration)
 
 }

--- a/shared/src/main/scala/amf/client/exported/config/AMFEventListener.scala
+++ b/shared/src/main/scala/amf/client/exported/config/AMFEventListener.scala
@@ -26,7 +26,7 @@ import amf.client.remote.Content
 import amf.client.validate.AMFValidationReport
 
 /**
-  * Defines an event listener linked to a specific {@link AMFEvent}
+  * Defines an event listener linked to a specific [[AMFEvent]]
   */
 @JSExportAll
 trait AMFEventListener {

--- a/shared/src/main/scala/amf/client/exported/config/ShapeRenderOptions.scala
+++ b/shared/src/main/scala/amf/client/exported/config/ShapeRenderOptions.scala
@@ -15,6 +15,7 @@ case class ShapeRenderOptions(private[amf] val _internal: InternalShapeRenderOpt
   def isWithCompactedEmission: Boolean = _internal.isWithCompactedEmission
   def schemaVersion: JSONSchemaVersion = _internal.schemaVersion
 
+  /** Remove documentation info as examples, descriptions, display names, etc. */
   def withoutDocumentation: ShapeRenderOptions = _internal.withoutDocumentation
 
   /** Render shape extracting common types to definitions. */

--- a/shared/src/main/scala/amf/client/remod/AMFGraphClient.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFGraphClient.scala
@@ -18,95 +18,98 @@ class AMFGraphClient(protected val configuration: AMFGraphConfiguration) {
   def getConfiguration: AMFGraphConfiguration = configuration
 
   /**
-    * Asynchronously generate a BaseUnit from the unit located in the given url.
+    * Asynchronously generate a BaseUnit from the content located in the given url.
     * @param url Location of the file to parse
-    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parse(url: String): Future[AMFResult] = AMFParser.parse(url, configuration)
 
   /**
-    * Asynchronously generate a BaseUnit from the unit located in the given url.
+    * Asynchronously generate a BaseUnit from the content located in the given url.
     * @param url Location of the file to parse
-    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
-    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parse(url: String, mediaType: String): Future[AMFResult] = AMFParser.parse(url, mediaType, configuration)
 
   /**
     * Asynchronously generate a BaseUnit from a given string.
-    * @param content The unit as a string
-    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param content The content as a string
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parseContent(content: String): Future[AMFResult] = AMFParser.parseContent(content, configuration)
 
   /**
     * Asynchronously generate a BaseUnit from a given string.
-    * @param content The unit as a string
-    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
-    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
-    * @example <code>parseContent("example content", "application/oas20+yaml")</code>
+    * @param content The content as a string
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parseContent(content: String, mediaType: String): Future[AMFResult] =
     AMFParser.parseContent(content, mediaType, configuration)
 
   /**
-    * Transforms a [[amf.core.model.document.BaseUnit]] with the default configuration
-    * @param bu [[amf.core.model.document.BaseUnit]] to transform
-    * @return An [[amf.client.remod.AMFResult]] with the transformed BaseUnit and it's report
+    * Transforms a [[BaseUnit]] with the default configuration
+    * @param bu [[BaseUnit]] to transform
+    * @return An [[AMFResult]] with the transformed BaseUnit and it's report
     */
   def transform(bu: BaseUnit): AMFResult = AMFTransformer.transform(bu, configuration)
 
   /**
-    * Transforms a [[amf.core.model.document.BaseUnit]] with a specific pipeline
-    * @param bu [[amf.core.model.document.BaseUnit]] to transform
+    * Transforms a [[BaseUnit]] with a specific pipeline
+    * @param bu [[BaseUnit]] to transform
     * @param pipelineName name of any custom or [[AMFGraphConfiguration.predefined predefined]] pipeline
-    * @return An [[amf.client.remod.AMFResult]] with the transformed BaseUnit and it's report
+    * @return An [[AMFResult]] with the transformed BaseUnit and it's report
     */
   def transform(bu: BaseUnit, pipelineName: String): AMFResult =
     AMFTransformer.transform(bu, pipelineName, configuration)
 
   /**
-    * Render a [[amf.core.model.document.BaseUnit]] to its default type
-    * @param bu [[amf.core.model.document.BaseUnit]] to be rendered
-    * @return the unit rendered
+    * Render a [[BaseUnit]] to its default type
+    * @param bu [[BaseUnit]] to be rendered
+    * @return The content rendered
     */
   def render(bu: BaseUnit): String = AMFRenderer.render(bu, configuration)
 
   /**
-    * Render a [[amf.core.model.document.BaseUnit]] and return the AST
-    * @param bu [[amf.core.model.document.BaseUnit]] to be rendered
-    * @return the AST as a [[org.yaml.model.YDocument]]
+    * Render a [[BaseUnit]] and return the AST
+    * @param bu [[BaseUnit]] to be rendered
+    * @return the AST as a [[YDocument]]
     */
   def renderAST(bu: BaseUnit): YDocument = AMFRenderer.renderAST(bu, configuration)
 
   /**
-    * Render a [[amf.core.model.document.BaseUnit]] to a certain mediaType
-    * @param bu [[amf.core.model.document.BaseUnit]] to be rendered
-    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
-    * @return the unit rendered
+    * Render a [[BaseUnit]] to a certain mediaType
+    * @param bu [[BaseUnit]] to be rendered
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @return The content rendered
     */
   def render(bu: BaseUnit, mediaType: String): String = AMFRenderer.render(bu, mediaType, configuration)
 
   /**
-    * Render a [[amf.core.model.document.BaseUnit]] to a certain mediaType and return the AST
-    * @param bu [[amf.core.model.document.BaseUnit]] to be rendered
-    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
-    * @return the AST as a [[org.yaml.model.YDocument]]
+    * Render a [[BaseUnit]] to a certain mediaType and return the AST
+    * @param bu [[BaseUnit]] to be rendered
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @return the AST as a [[YDocument]]
     */
   def renderAST(bu: BaseUnit, mediaType: String): YDocument = AMFRenderer.renderAST(bu, mediaType, configuration)
 
   /**
-    * Validate a [[amf.core.model.document.BaseUnit]] with its default validation profile
-    * @param bu [[amf.core.model.document.BaseUnit]] to validate
-    * @return an [[amf.core.validation.AMFValidationReport]]
+    * Validate a [[BaseUnit]] with its default validation profile name
+    * @param bu [[BaseUnit]] to validate
+    * @return an [[AMFValidationReport]]
     */
   def validate(bu: BaseUnit): AMFValidationReport = AMFValidator.validate(bu, configuration)
 
   /**
-    * Validate a [[amf.core.model.document.BaseUnit]] with a specific validation profile
-    * @param bu [[amf.core.model.document.BaseUnit]] to validate
+    * Validate a [[BaseUnit]] with a specific validation profile name
+    * @param bu [[BaseUnit]] to validate
     * @param profileName the [[amf.ProfileName]] of the desired validation profile
-    * @return an [[amf.core.validation.AMFValidationReport]]
+    * @return an [[AMFValidationReport]]
     */
   def validate(bu: BaseUnit, profileName: ProfileName): AMFValidationReport =
     AMFValidator.validate(bu, profileName, configuration)

--- a/shared/src/main/scala/amf/client/remod/AMFGraphClient.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFGraphClient.scala
@@ -1,41 +1,113 @@
 package amf.client.remod
 
 import amf.ProfileName
-import amf.client.convert.CoreClientConverters.platform
-import amf.client.parse.DefaultParserErrorHandler
-import amf.core.client.ParsingOptions
-import amf.core.errorhandling.ErrorHandler
 import amf.core.model.document.BaseUnit
-import amf.core.remote.{Cache, Context, Vendor}
-import amf.core.resolution.pipelines.TransformationPipeline
-import amf.core.services.RuntimeCompiler
 import amf.core.validation.AMFValidationReport
 import org.yaml.model.YDocument
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/**
+  * Contains common AMF graph operations.
+  * Base client for <code>AMLClient</code> and <code>AMFClient</code>.
+  */
 class AMFGraphClient(protected val configuration: AMFGraphConfiguration) {
 
   implicit val exec: ExecutionContext = configuration.getExecutionContext
 
   def getConfiguration: AMFGraphConfiguration = configuration
 
-  def parse(url: String): Future[AMFResult]                    = AMFParser.parse(url, configuration)
+  /**
+    * Asynchronously generate a BaseUnit from the unit located in the given url.
+    * @param url Location of the file to parse
+    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    */
+  def parse(url: String): Future[AMFResult] = AMFParser.parse(url, configuration)
+
+  /**
+    * Asynchronously generate a BaseUnit from the unit located in the given url.
+    * @param url Location of the file to parse
+    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
+    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    */
   def parse(url: String, mediaType: String): Future[AMFResult] = AMFParser.parse(url, mediaType, configuration)
-  def parseContent(content: String): Future[AMFResult]         = AMFParser.parseContent(content, configuration)
+
+  /**
+    * Asynchronously generate a BaseUnit from a given string.
+    * @param content The unit as a string
+    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    */
+  def parseContent(content: String): Future[AMFResult] = AMFParser.parseContent(content, configuration)
+
+  /**
+    * Asynchronously generate a BaseUnit from a given string.
+    * @param content The unit as a string
+    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
+    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @example <code>parseContent("example content", "application/oas20+yaml")</code>
+    */
   def parseContent(content: String, mediaType: String): Future[AMFResult] =
     AMFParser.parseContent(content, mediaType, configuration)
 
+  /**
+    * Transforms a [[amf.core.model.document.BaseUnit]] with the default configuration
+    * @param bu [[amf.core.model.document.BaseUnit]] to transform
+    * @return An [[amf.client.remod.AMFResult]] with the transformed BaseUnit and it's report
+    */
   def transform(bu: BaseUnit): AMFResult = AMFTransformer.transform(bu, configuration)
+
+  /**
+    * Transforms a [[amf.core.model.document.BaseUnit]] with a specific pipeline
+    * @param bu [[amf.core.model.document.BaseUnit]] to transform
+    * @param pipelineName name of any custom or [[AMFGraphConfiguration.predefined predefined]] pipeline
+    * @return An [[amf.client.remod.AMFResult]] with the transformed BaseUnit and it's report
+    */
   def transform(bu: BaseUnit, pipelineName: String): AMFResult =
     AMFTransformer.transform(bu, pipelineName, configuration)
 
-  def render(bu: BaseUnit): String                          = AMFRenderer.render(bu, configuration)
-  def renderAST(bu: BaseUnit): YDocument                    = AMFRenderer.renderAST(bu, configuration)
-  def render(bu: BaseUnit, mediaType: String): String       = AMFRenderer.render(bu, mediaType, configuration)
+  /**
+    * Render a [[amf.core.model.document.BaseUnit]] to its default type
+    * @param bu [[amf.core.model.document.BaseUnit]] to be rendered
+    * @return the unit rendered
+    */
+  def render(bu: BaseUnit): String = AMFRenderer.render(bu, configuration)
+
+  /**
+    * Render a [[amf.core.model.document.BaseUnit]] and return the AST
+    * @param bu [[amf.core.model.document.BaseUnit]] to be rendered
+    * @return the AST as a [[org.yaml.model.YDocument]]
+    */
+  def renderAST(bu: BaseUnit): YDocument = AMFRenderer.renderAST(bu, configuration)
+
+  /**
+    * Render a [[amf.core.model.document.BaseUnit]] to a certain mediaType
+    * @param bu [[amf.core.model.document.BaseUnit]] to be rendered
+    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
+    * @return the unit rendered
+    */
+  def render(bu: BaseUnit, mediaType: String): String = AMFRenderer.render(bu, mediaType, configuration)
+
+  /**
+    * Render a [[amf.core.model.document.BaseUnit]] to a certain mediaType and return the AST
+    * @param bu [[amf.core.model.document.BaseUnit]] to be rendered
+    * @param mediaType The nature and format of the given content. must be <code>"application/spec"</code> and may also include format
+    * @return the AST as a [[org.yaml.model.YDocument]]
+    */
   def renderAST(bu: BaseUnit, mediaType: String): YDocument = AMFRenderer.renderAST(bu, mediaType, configuration)
 
+  /**
+    * Validate a [[amf.core.model.document.BaseUnit]] with its default validation profile
+    * @param bu [[amf.core.model.document.BaseUnit]] to validate
+    * @return an [[amf.core.validation.AMFValidationReport]]
+    */
   def validate(bu: BaseUnit): AMFValidationReport = AMFValidator.validate(bu, configuration)
+
+  /**
+    * Validate a [[amf.core.model.document.BaseUnit]] with a specific validation profile
+    * @param bu [[amf.core.model.document.BaseUnit]] to validate
+    * @param profileName the [[amf.ProfileName]] of the desired validation profile
+    * @return an [[amf.core.validation.AMFValidationReport]]
+    */
   def validate(bu: BaseUnit, profileName: ProfileName): AMFValidationReport =
     AMFValidator.validate(bu, profileName, configuration)
 }

--- a/shared/src/main/scala/amf/client/remod/AMFGraphConfiguration.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFGraphConfiguration.scala
@@ -12,7 +12,6 @@ import amf.internal.reference.UnitCache
 import amf.internal.resource.ResourceLoader
 import amf.plugins.document.graph.{AMFGraphParsePlugin, AMFGraphRenderPlugin}
 
-import java.rmi.registry.LocateRegistry.getRegistry
 import scala.concurrent.ExecutionContext
 // all constructors only visible from amf. Users should always use builders or defaults
 
@@ -31,13 +30,11 @@ object AMFGraphConfiguration {
 
   /**
     * Predefined AMF core environment with:
-    * <ul>
-    *   <li>AMF Resolvers predefined {@link amf.client.remod.amfcore.config.AMFResolvers.predefined}</li>
-    *   <li>Default error handler provider that will create a {@link amf.client.parse.DefaultParserErrorHandler}</li>
-    *   <li>Empty {@link amf.client.remod.amfcore.registry.AMFRegistry}</li>
-    *   <li>MutedLogger: {@link amf.client.remod.amfcore.config.MutedLogger}</li>
-    *   <li>Without Any listener</li>
-    * </ul>
+    *   - AMF Resolvers [[amf.client.remod.amfcore.config.AMFResolvers.predefined predefined]]
+    *   - Default error handler provider that will create a [[amf.client.parse.DefaultParserErrorHandler]]
+    *   - Empty [[amf.client.remod.amfcore.registry.AMFRegistry]]
+    *   - MutedLogger: [[amf.client.exported.config.MutedLogger]]
+    *   - Without Any listener
     */
   def predefined(): AMFGraphConfiguration = {
     new AMFGraphConfiguration(
@@ -63,12 +60,12 @@ object AMFGraphConfiguration {
 
 /**
   * Base AMF configuration object
-  * @param resolvers {@link amf.client.remod.amfcore.config.AMFResolvers}
-  * @param errorHandlerProvider {@link amf.client.remod.ErrorHandlerProvider}
-  * @param registry {@link amf.client.remod.amfcore.registry.AMFRegistry}
-  * @param logger {@link amf.client.remod.amfcore.config.AMFLogger}
-  * @param listeners a Set of {@link amf.client.remod.amfcore.config.AMFEventListener}
-  * @param options {@link amf.client.remod.amfcore.config.AMFOptions}
+  * @param resolvers [[amf.client.remod.amfcore.config.AMFResolvers]]
+  * @param errorHandlerProvider [[amf.client.remod.ErrorHandlerProvider]]
+  * @param registry [[amf.client.remod.amfcore.registry.AMFRegistry]]
+  * @param logger [[amf.client.exported.config.AMFLogger]]
+  * @param listeners a Set of [[amf.client.remod.amfcore.config.AMFEventListener]]
+  * @param options [[amf.client.remod.amfcore.config.AMFOptions]]
   */
 class AMFGraphConfiguration private[amf] (override private[amf] val resolvers: AMFResolvers,
                                           override private[amf] val errorHandlerProvider: ErrorHandlerProvider,
@@ -115,7 +112,7 @@ class AMFGraphConfiguration private[amf] (override private[amf] val resolvers: A
 
   /**
     * AMF internal method just to facilitate the construction
-    * @param pipelines a list of {@link amf.core.resolution.pipelines.TransformationPipeline}
+    * @param pipelines a list of [[amf.core.resolution.pipelines.TransformationPipeline]]
     * @return
     */
   private[amf] def withTransformationPipelines(pipelines: List[TransformationPipeline]): AMFGraphConfiguration =

--- a/shared/src/main/scala/amf/client/remod/AMFParser.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFParser.scala
@@ -10,8 +10,8 @@ object AMFParser {
   /**
     * Asynchronously generate a BaseUnit from the unit located in the given url.
     * @param url Location of the api
-    * @param configuration [[amf.client.remod.AMFGraphConfiguration]]
-    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param configuration [[AMFGraphConfiguration]]
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parse(url: String, configuration: AMFGraphConfiguration): Future[AMFResult] =
     parseAsync(url, None, configuration)
@@ -19,8 +19,9 @@ object AMFParser {
   /**
     * Asynchronously generate a BaseUnit from the unit located in the given url.
     * @param url Location of the api
-    * @param mediaType The type of the file to parse
-    * @param configuration [[amf.client.remod.AMFGraphConfiguration]]
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @param configuration [[AMFGraphConfiguration]]
     * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
     */
   // check Vendor , only param? ParseParams?
@@ -30,8 +31,8 @@ object AMFParser {
   /**
     * Asynchronously generate a BaseUnit from a given string.
     * @param content The unit to parse as a string
-    * @param configuration [[amf.client.remod.AMFGraphConfiguration]]
-    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param configuration [[AMFGraphConfiguration]]
+    * @return A CompletableFuture of [[AMFResult]]
     */
   def parseContent(content: String, configuration: AMFGraphConfiguration): Future[AMFResult] = ???
 //    parseAsync(DEFAULT_DOCUMENT_URL, Some(fromStream(stream)), env)
@@ -39,8 +40,9 @@ object AMFParser {
   /**
     * Asynchronously generate a BaseUnit from a given string.
     * @param content The unit as a string
-    * @param mediaType The type of the file to parse
-    * @param configuration [[amf.client.remod.AMFGraphConfiguration]]
+    * @param mediaType The nature and format of the given content. Must be <code>"application/spec"</code> or <code>"application/spec+syntax"</code>.
+    *                  Examples: <code>"application/raml10"</code> or <code>"application/raml10+yaml"</code>
+    * @param configuration [[AMFGraphConfiguration]]
     * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
     */
   def parseContent(content: String, mediaType: String, configuration: AMFGraphConfiguration): Future[AMFResult] = ???

--- a/shared/src/main/scala/amf/client/remod/AMFParser.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFParser.scala
@@ -9,40 +9,46 @@ object AMFParser {
 
   /**
     * Asynchronously generate a BaseUnit from the unit located in the given url.
-    * @param url : Location of the api.
-    * @param env: AnfEnvironment
-    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param url Location of the api
+    * @param configuration [[amf.client.remod.AMFGraphConfiguration]]
+    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
     */
-  def parse(url: String, env: AMFGraphConfiguration): Future[AMFResult] = parseAsync(url, None, env)
+  def parse(url: String, configuration: AMFGraphConfiguration): Future[AMFResult] =
+    parseAsync(url, None, configuration)
 
   /**
     * Asynchronously generate a BaseUnit from the unit located in the given url.
-    * @param url : Location of the api.
+    * @param url Location of the api
+    * @param mediaType The type of the file to parse
+    * @param configuration [[amf.client.remod.AMFGraphConfiguration]]
     * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
     */
   // check Vendor , only param? ParseParams?
-  def parse(url: String, mediaType: String, env: AMFGraphConfiguration): Future[AMFResult] =
-    parseAsync(url, Some(mediaType), env)
+  def parse(url: String, mediaType: String, configuration: AMFGraphConfiguration): Future[AMFResult] =
+    parseAsync(url, Some(mediaType), configuration)
 
   /**
     * Asynchronously generate a BaseUnit from a given string.
-    * @param content: The unit as a string
-    * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
+    * @param content The unit to parse as a string
+    * @param configuration [[amf.client.remod.AMFGraphConfiguration]]
+    * @return A client future that will have a BaseUnit or an error to handle the result of such invocation.
     */
-  def parseContent(content: String, env: AMFGraphConfiguration): Future[AMFResult] = ???
+  def parseContent(content: String, configuration: AMFGraphConfiguration): Future[AMFResult] = ???
 //    parseAsync(DEFAULT_DOCUMENT_URL, Some(fromStream(stream)), env)
 
   /**
     * Asynchronously generate a BaseUnit from a given string.
-    * @param stream: The unit as a string
+    * @param content The unit as a string
+    * @param mediaType The type of the file to parse
+    * @param configuration [[amf.client.remod.AMFGraphConfiguration]]
     * @return A future that will have a BaseUnit or an error to handle the result of such invocation.
     */
-  def parseContent(content: String, mediaType: String, env: AMFGraphConfiguration): Future[AMFResult] = ???
+  def parseContent(content: String, mediaType: String, configuration: AMFGraphConfiguration): Future[AMFResult] = ???
 //    parseAsync(DEFAULT_DOCUMENT_URL, Some(fromStream(stream)))
 
   private[amf] def parseAsync(url: String,
                               mediaType: Option[String],
-                              amfEnvironment: AMFGraphConfiguration): Future[AMFResult] = ???
+                              configuration: AMFGraphConfiguration): Future[AMFResult] = ???
 
   private def fromStream(url: String, stream: String): ResourceLoader =
     StringResourceLoader(platform.resolvePath(url), stream)

--- a/shared/src/main/scala/amf/client/remod/AMFRenderer.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFRenderer.scala
@@ -5,19 +5,12 @@ import org.yaml.model.YDocument
 
 object AMFRenderer {
 
-  def render(bu: BaseUnit, env: AMFGraphConfiguration): String = ???
+  def render(bu: BaseUnit, configuration: AMFGraphConfiguration): String = ???
 
-  def renderAST(bu: BaseUnit, env: AMFGraphConfiguration): YDocument = ???
+  def renderAST(bu: BaseUnit, configuration: AMFGraphConfiguration): YDocument = ???
 
-  /**
-    *
-    * @param bu
-    * @param target media type which specifies a vendor, and optionally a syntax.
-    * @param env
-    * @return
-    */
-  def render(bu: BaseUnit, mediaType: String, env: AMFGraphConfiguration): String = ???
+  def render(bu: BaseUnit, mediaType: String, configuration: AMFGraphConfiguration): String = ???
 
-  def renderAST(bu: BaseUnit, mediaType: String, env: AMFGraphConfiguration): YDocument = ???
+  def renderAST(bu: BaseUnit, mediaType: String, configuration: AMFGraphConfiguration): YDocument = ???
 
 }

--- a/shared/src/main/scala/amf/client/remod/AMFResult.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFResult.scala
@@ -7,8 +7,8 @@ import scala.concurrent.Future
 
 /**
   *
-  * @param bu {@link amf.core.model.document.BaseUnit} returned from AMF parse or transform
-  * @param result the resultant {@link amf.core.validation.AMFValidationReport} of the BaseUnit
+  * @param bu [[amf.core.model.document.BaseUnit]] returned from AMF parse or transform
+  * @param result the resultant [[amf.core.validation.AMFValidationReport]] of the BaseUnit
   */
 case class AMFResult(bu: BaseUnit, result: AMFValidationReport) {
   def conforms: Boolean = result.conforms

--- a/shared/src/main/scala/amf/client/remod/AMFResult.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFResult.scala
@@ -7,8 +7,10 @@ import scala.concurrent.Future
 
 /**
   *
-  * @param bu [[amf.core.model.document.BaseUnit]] returned from AMF parse or transform
-  * @param result the resultant [[amf.core.validation.AMFValidationReport]] of the BaseUnit
+  * @param bu [[BaseUnit]] returned from AMF parse or transform. It can be:
+  *  - A [[BaseUnit]] when parsing/transformation is successful
+  *  - The most complete unit that could be built, and an [[AMFValidationReport]] report with errors/warnings found
+  * @param result the resultant [[AMFValidationReport]] of the BaseUnit
   */
 case class AMFResult(bu: BaseUnit, result: AMFValidationReport) {
   def conforms: Boolean = result.conforms

--- a/shared/src/main/scala/amf/client/remod/AMFTransformer.scala
+++ b/shared/src/main/scala/amf/client/remod/AMFTransformer.scala
@@ -4,9 +4,9 @@ import amf.core.model.document.BaseUnit
 
 object AMFTransformer {
 
-  def transform(unit: BaseUnit, conf: AMFGraphConfiguration): AMFResult = ???
+  def transform(unit: BaseUnit, configuration: AMFGraphConfiguration): AMFResult = ???
 
-  def transform(unit: BaseUnit, pipelineName: String, conf: AMFGraphConfiguration): AMFResult = ???
+  def transform(unit: BaseUnit, pipelineName: String, configuration: AMFGraphConfiguration): AMFResult = ???
 //  {
 //    val pipelines = conf.registry.transformationPipelines
 //    val pipeline  = pipelines.get(pipelineName)

--- a/shared/src/main/scala/amf/client/remod/amfcore/config/AMFOptions.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/config/AMFOptions.scala
@@ -2,11 +2,12 @@ package amf.client.remod.amfcore.config
 
 /**
   * A set of options to customize parsing and rendering
-  * @param parsingOptions {@link amf.client.remod.amfcore.config.ParsingOptions}
-  * @param renderOptions {@link amf.client.remod.amfcore.config.RenderOptions}
+  * @param parsingOptions [[amf.client.remod.amfcore.config.ParsingOptions]]
+  * @param renderOptions [[amf.client.remod.amfcore.config.RenderOptions]]
   */
-private[amf] case class AMFOptions(parsingOptions: ParsingOptions,
-                                   renderOptions: RenderOptions /*, private[amf] var env:AmfEnvironment*/ ) {
+private[amf] case class AMFOptions(
+    parsingOptions: ParsingOptions,
+    renderOptions: RenderOptions /*, private[amf] var configuration:AMFConfiguration*/ ) {
   //  def withPrettyPrint(): AmfEnvironment = {
   //    val copied = copy(renderingOptions = renderingOptions.withPrettyPrint)
   //    val newEnv = env.copy(options = copied)
@@ -17,6 +18,6 @@ private[amf] case class AMFOptions(parsingOptions: ParsingOptions,
 
 object AMFOptions {
 
-  /** Creates a default {@link amf.client.remod.amfcore.config.AMFOptions} */
+  /** Creates a default [[amf.client.remod.amfcore.config.AMFOptions]] */
   def default() = new AMFOptions(ParsingOptions(), RenderOptions())
 }

--- a/shared/src/main/scala/amf/client/remod/amfcore/config/AMFResolvers.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/config/AMFResolvers.scala
@@ -12,9 +12,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Configuration object for resolvers
-  * @param resourceLoaders a list of {@link amf.internal.resource.ResourceLoader} to use
-  * @param unitCache a {@link amf.internal.reference.UnitCache} that stores {@link amf.core.model.document.BaseUnit} resolved
-  * @param executionContext the {@link amf.client.execution.BaseExecutionEnvironment} to use
+  * @param resourceLoaders a list of [[amf.internal.resource.ResourceLoader]] to use
+  * @param unitCache a [[amf.internal.reference.UnitCache]] that stores [[amf.core.model.document.BaseUnit]] resolved
+  * @param executionContext the [[amf.client.execution.BaseExecutionEnvironment]] to use
   */
 private[amf] case class AMFResolvers(resourceLoaders: List[ResourceLoader],
                                      val unitCache: Option[UnitCache],

--- a/shared/src/main/scala/amf/client/remod/amfcore/plugins/render/RenderConfiguration.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/plugins/render/RenderConfiguration.scala
@@ -21,13 +21,13 @@ case class DefaultRenderConfiguration(renderPlugins: List[AMFRenderPlugin],
     extends RenderConfiguration
 
 object DefaultRenderConfiguration {
-  def apply(env: AMFGraphConfiguration): RenderConfiguration = {
+  def apply(configuration: AMFGraphConfiguration): RenderConfiguration = {
     DefaultRenderConfiguration(
-        env.registry.plugins.renderPlugins,
-        env.registry.plugins.namespacePlugins,
-        env.options.renderOptions,
-        env.errorHandlerProvider.errorHandler(),
-        env.listeners
+        configuration.registry.plugins.renderPlugins,
+        configuration.registry.plugins.namespacePlugins,
+        configuration.options.renderOptions,
+        configuration.errorHandlerProvider.errorHandler(),
+        configuration.listeners
     )
   }
 }

--- a/shared/src/main/scala/amf/client/remod/amfcore/registry/AMFRegistry.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/registry/AMFRegistry.scala
@@ -8,10 +8,10 @@ import amf.core.validation.core.ValidationProfile
 
 /**
   * Registry to store plugins, entities, transformation pipelines and constraint rules
-  * @param plugins                 {@link amf.client.remod.amfcore.registry.PluginsRegistry}
-  * @param entitiesRegistry        {@link amf.client.remod.amfcore.registry.EntitiesRegistry}
-  * @param transformationPipelines a map of {@link amf.core.resolution.pipelines.TransformationPipeline}s
-  * @param constraintsRules        a map of {@link amf.ProfileName} -> {@link amf.core.validation.core.ValidationProfile}
+  * @param plugins                 [[amf.client.remod.amfcore.registry.PluginsRegistry]]
+  * @param entitiesRegistry        [[amf.client.remod.amfcore.registry.EntitiesRegistry]]
+  * @param transformationPipelines a map of [[amf.core.resolution.pipelines.TransformationPipeline]]s
+  * @param constraintsRules        a map of [[amf.ProfileName]] -> [[amf.core.validation.core.ValidationProfile]]
   */
 private[amf] case class AMFRegistry(plugins: PluginsRegistry,
                                     entitiesRegistry: EntitiesRegistry,

--- a/shared/src/main/scala/amf/client/remod/amfcore/registry/PluginsRegistry.scala
+++ b/shared/src/main/scala/amf/client/remod/amfcore/registry/PluginsRegistry.scala
@@ -1,19 +1,17 @@
 package amf.client.remod.amfcore.registry
 
-import amf.ProfileName
 import amf.client.remod.amfcore.plugins.AMFPlugin
 import amf.client.remod.amfcore.plugins.namespace.NamespaceAliasesPlugin
 import amf.client.remod.amfcore.plugins.parse.{AMFParsePlugin, DomainParsingFallback, ExternalFragmentDomainFallback}
 import amf.client.remod.amfcore.plugins.render.AMFRenderPlugin
 import amf.client.remod.amfcore.plugins.validate.AMFValidatePlugin
-import amf.core.model.document.BaseUnit
 
 /**
   * A registry of plugins
-  * @param parsePlugins a list of {@link amf.client.remod.amfcore.plugins.parse.AMFParsePlugin}
-  * @param validatePlugins a list of {@link amf.client.remod.amfcore.plugins.validate.AMFValidatePlugin}
-  * @param renderPlugins a list of {@link amf.client.remod.amfcore.plugins.render.AMFRenderPlugin}
-  * @param domainParsingFallback {@link amf.client.remod.amfcore.plugins.parse.DomainParsingFallback}
+  * @param parsePlugins a list of [[amf.client.remod.amfcore.plugins.parse.AMFParsePlugin]]
+  * @param validatePlugins a list of [[amf.client.remod.amfcore.plugins.validate.AMFValidatePlugin]]
+  * @param renderPlugins a list of [[amf.client.remod.amfcore.plugins.render.AMFRenderPlugin]]
+  * @param domainParsingFallback [[amf.client.remod.amfcore.plugins.parse.DomainParsingFallback]]
   */
 case class PluginsRegistry private[amf] (parsePlugins: List[AMFParsePlugin],
                                          validatePlugins: List[AMFValidatePlugin],

--- a/shared/src/main/scala/amf/core/AMFCompiler.scala
+++ b/shared/src/main/scala/amf/core/AMFCompiler.scala
@@ -2,13 +2,7 @@ package amf.core
 
 import amf.client.parse.DefaultParserErrorHandler
 import amf.client.remod.AMFGraphConfiguration
-import amf.client.remod.amfcore.config.{
-  AMFEvent,
-  ParsedModelEvent,
-  ParsedSyntaxEvent,
-  ParsingOptionsConverter,
-  StartingContentParsingEvent
-}
+import amf.client.remod.amfcore.config._
 import amf.client.remod.amfcore.plugins.parse.{AMFParsePlugin, ParsingInfo}
 import amf.client.remote.Content
 import amf.core.TaggedReferences._
@@ -102,7 +96,7 @@ class CompilerContextBuilder(url: String,
   private var givenContent: Option[ParserContext]    = None
   private var cache                                  = Cache()
   private var normalizeUri: Boolean                  = true
-  private var env: AMFGraphConfiguration             = AMFPluginsRegistry.obtainStaticConfig()
+  private var configuration: AMFGraphConfiguration   = AMFPluginsRegistry.obtainStaticConfig()
   private var allowedMediaTypes: Option[Seq[String]] = None
 
   def withBaseParserContext(parserContext: ParserContext): this.type = {
@@ -121,13 +115,13 @@ class CompilerContextBuilder(url: String,
   }
 
   def withEnvironment(environment: Environment): CompilerContextBuilder = {
-    val newEnv = AMFGraphConfiguration.fromLegacy(this.env, environment)
-    this.env = newEnv
+    val newEnv = AMFGraphConfiguration.fromLegacy(this.configuration, environment)
+    this.configuration = newEnv
     this
   }
 
   def withBaseEnvironment(environment: AMFGraphConfiguration): CompilerContextBuilder = {
-    this.env = environment
+    this.configuration = environment
     this
   }
 
@@ -168,7 +162,7 @@ class CompilerContextBuilder(url: String,
 
   def build()(implicit executionContext: ExecutionContext): CompilerContext = {
     val fc = buildFileContext()
-    new CompilerContext(url, path, buildParserContext(fc), fc, cache, this.env, allowedMediaTypes)
+    new CompilerContext(url, path, buildParserContext(fc), fc, cache, this.configuration, allowedMediaTypes)
   }
 }
 

--- a/shared/src/main/scala/amf/core/registries/AMFPluginsRegistry.scala
+++ b/shared/src/main/scala/amf/core/registries/AMFPluginsRegistry.scala
@@ -10,7 +10,7 @@ import amf.core.validation.core.ValidationProfile
 import scala.collection.mutable
 
 object AMFPluginsRegistry {
-  // all static registries will end up here, and with a mayor version release the AmfEnvironment will not be static
+  // all static registries will end up here, and with a mayor version release the AMFGraphConfiguration will not be static
   private[amf] var staticConfiguration: AMFGraphConfiguration = AMFGraphConfiguration.predefined()
 
   private val syntaxPluginIDRegistry: mutable.HashMap[String, AMFSyntaxPlugin]     = mutable.HashMap()

--- a/shared/src/main/scala/amf/core/remote/Platform.scala
+++ b/shared/src/main/scala/amf/core/remote/Platform.scala
@@ -126,9 +126,9 @@ trait Platform extends FileMediaType {
   }
 
   /** Resolve remote url. */
-  def fetchContent(url: String, env: AMFGraphConfiguration)(
+  def fetchContent(url: String, configuration: AMFGraphConfiguration)(
       implicit executionContext: ExecutionContext): Future[Content] =
-    loaderConcat(url, env.getResourceLoaders.filter(_.accepts(url)))
+    loaderConcat(url, configuration.getResourceLoaders.filter(_.accepts(url)))
 
   /** Platform out of the box [ResourceLoader]s */
   def loaders(exec: BaseExecutionEnvironment = defaultExecutionEnvironment): Seq[ResourceLoader] = {

--- a/shared/src/main/scala/amf/core/unsafe/PlatformSecrets.scala
+++ b/shared/src/main/scala/amf/core/unsafe/PlatformSecrets.scala
@@ -78,7 +78,7 @@ case class TrunkPlatform(content: String,
 
   override def tmpdir(): String = throw new Exception("Unsupported tmpdir operation")
 
-  override def fetchContent(url: String, env: AMFGraphConfiguration)(
+  override def fetchContent(url: String, configuration: AMFGraphConfiguration)(
       implicit executionContext: ExecutionContext): Future[Content] =
     Future.successful(new Content(content, url, forcedMediaType))
 


### PR DESCRIPTION
- add scaladoc to remod exported files 
- refactor `env` or `amfEnvironment` parameter names with `configuration`