### PR TITLE
(cherry-pick to remod) APIMF-3125: use content url when parsing syntax (#275)

### DIFF
--- a/shared/src/main/scala/amf/core/internal/parser/AMFCompiler.scala
+++ b/shared/src/main/scala/amf/core/internal/parser/AMFCompiler.scala
@@ -200,10 +200,11 @@ class AMFCompiler(compilerContext: CompilerContext,
   }
 
   private def parseSyntaxForMediaType(content: Content, mime: String): Option[(String, ParsedDocument)] = {
+    val withContentUrl = compilerContext.parserContext.forLocation(content.url)
     // TODO ARM sort
     compilerContext.parserContext.config.sortedParseSyntax
       .find(_.applies(content.stream))
-      .map(p => (mime, p.parse(content.stream, mime, compilerContext.parserContext)))
+      .map(p => (mime, p.parse(content.stream, mime, withContentUrl)))
   }
 
   def parseExternalFragment(content: Content)(implicit executionContext: ExecutionContext): Future[BaseUnit] = Future {

--- a/shared/src/test/scala/amf/core/parser/CompilerRootUrlTest.scala
+++ b/shared/src/test/scala/amf/core/parser/CompilerRootUrlTest.scala
@@ -1,0 +1,43 @@
+package amf.core.parser
+
+import amf.core.client.common.remote.Content
+import amf.core.client.scala.AMFGraphConfiguration
+import amf.core.client.scala.parse.document.SyamlParsedDocument
+import amf.core.client.scala.resource.ResourceLoader
+import amf.core.internal.parser.{AMFCompiler, CompilerContextBuilder}
+import amf.core.internal.unsafe.PlatformSecrets
+import org.scalatest.{AsyncFunSuite, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CompilerRootUrlTest extends AsyncFunSuite with PlatformSecrets with Matchers {
+
+  override implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  class CustomContentUrlResourceLoader(customUrl: String) extends ResourceLoader {
+    override def fetch(resource: String): Future[Content] = Future.successful(
+        new Content("""
+          |{
+          |   "a": 5
+          |}""".stripMargin,
+                    customUrl)
+    )
+    override def accepts(resource: String): Boolean = true
+  }
+
+  test("Location of Root matches location in SyamlParsedDocument when resource loader returns custom url") {
+    val url          = "file://some/url.json"
+    val customUrl    = "file://some/other/url.json"
+    val customLoader = new CustomContentUrlResourceLoader(customUrl)
+
+    val config = AMFGraphConfiguration.predefined().withResourceLoaders(List(customLoader))
+    val context = new CompilerContextBuilder(url, platform, config.parseConfiguration)
+      .build()
+
+    new AMFCompiler(context, None).root().map { root =>
+      val document = root.parsed.asInstanceOf[SyamlParsedDocument]
+      root.location shouldBe customUrl
+      root.location shouldBe document.document.location.sourceName
+    }
+  }
+}


### PR DESCRIPTION
* APIMF-3125: use content url when parsing syntax

* include test for verifying url of Root and ParsedDocument when resource loader returns custom url