### PR TITLE
Redefine SyamlAMFErrorHandler to avoid undeterministic validations

### DIFF
--- a/shared/src/main/scala/amf/core/client/scala/errorhandling/AMFErrorHandler.scala
+++ b/shared/src/main/scala/amf/core/client/scala/errorhandling/AMFErrorHandler.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable
 
 trait AMFErrorHandler {
 
-  val results: mutable.LinkedHashSet[AMFValidationResult] = mutable.LinkedHashSet()
+  private val results: mutable.LinkedHashSet[AMFValidationResult] = mutable.LinkedHashSet()
 
   def getResults: List[AMFValidationResult] = results.toList
 

--- a/shared/src/main/scala/amf/core/internal/plugins/syntax/SyamlSyntaxParsePlugin.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/syntax/SyamlSyntaxParsePlugin.scala
@@ -41,13 +41,12 @@ class SyamlAMFErrorHandler(val eh: AMFErrorHandler)
     extends AMFErrorHandler
     with ParseErrorHandler
     with IllegalTypeHandler {
-  val syamleh = new SYamlAMFParserErrorHandler(eh)
+  override def report(result: AMFValidationResult): Unit = eh.report(result)
+  override def getResults: List[AMFValidationResult]     = eh.getResults
 
-  override val results: mutable.LinkedHashSet[AMFValidationResult] = eh.results
-
+  val syamleh                                                            = new SYamlAMFParserErrorHandler(eh)
   override def handle(location: SourceLocation, e: SyamlException): Unit = syamleh.handle(location, e)
-
-  override def handle[T](error: YError, defaultValue: T): T = syamleh.handle(error, defaultValue)
+  override def handle[T](error: YError, defaultValue: T): T              = syamleh.handle(error, defaultValue)
 }
 
 object SyamlSyntaxParsePlugin extends AMFSyntaxParsePlugin with PlatformSecrets {


### PR DESCRIPTION
Previous behaviour:
```
val client = RAMLConfiguration.RAML().baseUnitClient()
for {
  parsed   <- client.parse(api).asFuture // 29 syntax errors
  secondParsed   <- client.parse(api).asFuture // 1 syntax error
  thirdParsed   <- client.parse(api).asFuture // 111 syntax errors
}
```
syntax errors in multiple files become undeterministic, clear example in https://github.com/aml-org/amf/pull/1098.

Not 100% sure of the root cause, the change fixes the issue which implies it is likely that when overriding the results map the report method in AMFErrorHandler which is syncronized was not working correctly.