### PR TITLE
APIMF-3319: new SourceInformation node to store location of elements

### DIFF
--- a/adrs/0009-source-information-node-storing-source-locations.md
+++ b/adrs/0009-source-information-node-storing-source-locations.md
@@ -1,0 +1,27 @@
+# 9. Source information node storing source locations
+
+Date: 2021-11-01
+
+## Status
+
+Accepted
+
+## Context
+
+The custom AMF validator needs to show the location of the file from which each error was generated. 
+Given the current state of the amf model and emission of jsonld, there was no way to obtain the location of a specific node. 
+
+## Decision
+
+A new node was defined as a field in BaseUnit call BaseUnitSourceInformation, which has the necessary information to obtain the source location of any node.
+Internally, this node has two fields, one that stores the root location, and another that stores LocationInformation nodes which contain alternative locations with the ids of all the elements parsed from that location.
+A new render option was included making the emission of this node to jsonld optional and not activated by default.
+
+An alternative solution was to serialize SourceLocation annotation in each node, but this leads to a 25% or more increase in size of the resulting jsonld, as the paths are stored in a redundant fashion.
+
+## Consequences
+
+In large apis with multiple references to external files, the resulting jsonld is increased by around 4% when the option of source information is used.
+
+It is also important to take into account that this node is generated during parsing, so after resolution there will potentially be elements with new ids that won't match correctly in the source information structure.
+As the custom validator is currently using a non resolved model the generation of the source information node is done just before parsing, but ths will have to be adjusted if we decide to use a resolved model.

--- a/shared/src/main/scala/amf/core/client/platform/config/RenderOptions.scala
+++ b/shared/src/main/scala/amf/core/client/platform/config/RenderOptions.scala
@@ -21,8 +21,14 @@ case class RenderOptions(private[amf] val _internal: InternalRenderOptions) {
   /** Include source maps when rendering to graph. */
   def withSourceMaps(): RenderOptions = _internal.withSourceMaps
 
-  /** Include source maps when rendering to graph. */
+  /** Exclude  source maps when rendering to graph. */
   def withoutSourceMaps(): RenderOptions = _internal.withoutSourceMaps
+
+  /** Include source information node when rendering to graph. */
+  def withSourceInformation(): RenderOptions = _internal.withSourceInformation
+
+  /** Exclude source information node when rendering to graph. */
+  def withoutSourceInformation(): RenderOptions = _internal.withSourceInformation
 
   /** Emits JSON-LD with compact IRIs when rendering to graph. */
   def withCompactUris(): RenderOptions = _internal.withCompactUris
@@ -60,6 +66,7 @@ case class RenderOptions(private[amf] val _internal: InternalRenderOptions) {
 
   def isWithCompactUris: Boolean        = _internal.compactUris
   def isWithSourceMaps: Boolean         = _internal.sources
+  def isWithSourceInformation: Boolean  = _internal.sourceInformation
   def isAmfJsonLdSerialization: Boolean = _internal.amfJsonLdSerialization
   def isPrettyPrint: Boolean            = _internal.prettyPrint
   def isEmitNodeIds: Boolean            = _internal.emitNodeIds

--- a/shared/src/main/scala/amf/core/client/platform/model/document/BaseUnit.scala
+++ b/shared/src/main/scala/amf/core/client/platform/model/document/BaseUnit.scala
@@ -119,4 +119,6 @@ trait BaseUnit extends AmfObjectWrapper with PlatformSecrets {
     _internal.withProcessingData(data)
     this
   }
+
+  def sourceInformation: BaseUnitSourceInformation = _internal.sourceInformation
 }

--- a/shared/src/main/scala/amf/core/client/platform/model/document/BaseUnitSourceInformation.scala
+++ b/shared/src/main/scala/amf/core/client/platform/model/document/BaseUnitSourceInformation.scala
@@ -1,0 +1,51 @@
+package amf.core.client.platform.model.document
+
+import amf.core.client.platform.model.{AmfObjectWrapper, BoolField, StrField}
+import amf.core.client.scala.model.document.{BaseUnitSourceInformation => InternalBaseUnitSourceInformation}
+import amf.core.client.scala.model.document.{LocationInformation => InternalLocationInformation}
+import amf.core.internal.convert.CoreClientConverters._
+import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
+
+@JSExportAll
+class BaseUnitSourceInformation(private[amf] val _internal: InternalBaseUnitSourceInformation)
+    extends AmfObjectWrapper {
+
+  @JSExportTopLevel("BaseUnitSourceInformation")
+  def this() = this(InternalBaseUnitSourceInformation())
+
+  def rootLocation: StrField = _internal.rootLocation
+
+  def withRootLocation(value: String): this.type = {
+    _internal.withRootLocation(value)
+    this
+  }
+
+  def additionalLocations: ClientList[LocationInformation] = _internal.additionalLocations.asClient
+
+  def withAdditionalLocations(locations: ClientList[LocationInformation]): this.type = {
+    _internal.withAdditionalLocations(locations.asInternal)
+    this
+  }
+}
+
+@JSExportAll
+class LocationInformation(private[amf] val _internal: InternalLocationInformation) extends AmfObjectWrapper {
+
+  @JSExportTopLevel("LocationInformation")
+  def this() = this(InternalLocationInformation())
+
+  def locationValue: StrField = _internal.locationValue
+
+  def withLocation(value: String): this.type = {
+    _internal.withLocation(value)
+    this
+  }
+
+  def elements(): ClientList[StrField] = _internal.elements.asClient
+
+  def withElements(elements: ClientList[String]): this.type = {
+    _internal.withElements(elements.asInternal)
+    this
+  }
+
+}

--- a/shared/src/main/scala/amf/core/client/scala/config/RenderOptions.scala
+++ b/shared/src/main/scala/amf/core/client/scala/config/RenderOptions.scala
@@ -11,6 +11,7 @@ case class RenderOptions(
     sources: Boolean = false,
     compactUris: Boolean = false,
     rawSourceMaps: Boolean = false,
+    sourceInformation: Boolean = false,
     validating: Boolean = false,
     private[amf] val filterFields: Field => Boolean = (_: Field) => false,
     amfJsonLdSerialization: Boolean = true,
@@ -35,6 +36,12 @@ case class RenderOptions(
 
   /** Exclude source maps when rendering to graph. */
   def withoutSourceMaps: RenderOptions = copy(sources = false)
+
+  /** Include source information node when rendering to graph. */
+  def withSourceInformation: RenderOptions = copy(sourceInformation = true)
+
+  /** Exclude source information node when rendering to graph. */
+  def withoutSourceInformation: RenderOptions = copy(sourceInformation = false)
 
   /** Emits JSON-LD with compact IRIs when rendering to graph. */
   def withCompactUris: RenderOptions = copy(compactUris = true)
@@ -100,6 +107,7 @@ case class RenderOptions(
 
   def isCompactUris: Boolean             = compactUris
   def isWithSourceMaps: Boolean          = sources
+  def isWithSourceInformation: Boolean   = sourceInformation
   def isWithRawSourceMaps: Boolean       = rawSourceMaps
   def isAmfJsonLdSerialization: Boolean  = amfJsonLdSerialization
   def isValidation: Boolean              = validating

--- a/shared/src/main/scala/amf/core/client/scala/model/document/BaseUnit.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/document/BaseUnit.scala
@@ -99,6 +99,8 @@ trait BaseUnit extends AmfObject with MetaModelTypeMapping with PlatformSecrets 
 
   def withProcessingData(data: BaseUnitProcessingData): this.type = set(ProcessingData, data)
 
+  def sourceInformation: BaseUnitSourceInformation = fields.field(SourceInformation)
+
   @deprecated("Use processingData.withModelVersion for API Contract Base Units only", "AMF 5.0.0 & AML 6.0.0")
   private def withModelVersion(version: String): this.type = set(ModelVersion, version)
 
@@ -109,6 +111,9 @@ trait BaseUnit extends AmfObject with MetaModelTypeMapping with PlatformSecrets 
   def withPkg(pkg: String): this.type = set(Package, pkg)
   def withPkg(pkg: String, annotations: Annotations): this.type =
     set(Package, AmfScalar(pkg, annotations), Annotations.inferred())
+
+  private[amf] def withSourceInformation(sourceInfo: BaseUnitSourceInformation): this.type =
+    set(SourceInformation, sourceInfo)
 
   /** Returns Unit iterator for specified strategy and scope. */
   def iterator(strategy: IteratorStrategy = DomainElementStrategy,

--- a/shared/src/main/scala/amf/core/client/scala/model/document/BaseUnitSourceInformation.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/document/BaseUnitSourceInformation.scala
@@ -1,0 +1,52 @@
+package amf.core.client.scala.model.document
+
+import amf.core.client.scala.model.StrField
+import amf.core.client.scala.model.domain.AmfObject
+import amf.core.internal.metamodel.Obj
+import amf.core.internal.metamodel.document.{BaseUnitModel, BaseUnitSourceInformationModel, LocationInformationModel}
+import amf.core.internal.metamodel.document.BaseUnitSourceInformationModel._
+import amf.core.internal.metamodel.document.LocationInformationModel._
+import amf.core.internal.parser.domain.{Annotations, Fields}
+
+class BaseUnitSourceInformation(val fields: Fields, val annotations: Annotations) extends AmfObject {
+
+  /** Value , path + field value that is used to compose the id when the object its adopted */
+  override private[amf] def componentId = "/BaseUnitSourceInformation"
+
+  def rootLocation: StrField                     = fields.field(RootLocation)
+  def withRootLocation(value: String): this.type = set(RootLocation, value)
+
+  def additionalLocations: Seq[LocationInformation] = fields.field(AdditionalLocations)
+  def withAdditionalLocations(locations: Seq[LocationInformation]): this.type =
+    setArray(AdditionalLocations, locations)
+
+  override def meta: Obj = BaseUnitSourceInformationModel
+
+}
+
+object BaseUnitSourceInformation {
+  def apply(): BaseUnitSourceInformation = apply(Annotations())
+
+  def apply(annotations: Annotations): BaseUnitSourceInformation = new BaseUnitSourceInformation(Fields(), annotations)
+}
+
+class LocationInformation(val fields: Fields, val annotations: Annotations) extends AmfObject {
+
+  /** Value , path + field value that is used to compose the id when the object its adopted */
+  override private[amf] def componentId = "/LocationInformation"
+
+  def locationValue: StrField                = fields.field(BaseUnitModel.Location)
+  def withLocation(value: String): this.type = set(BaseUnitModel.Location, value)
+
+  def elements: Seq[StrField]                     = fields.field(Elements)
+  def withElements(value: Seq[String]): this.type = set(Elements, value)
+
+  override def meta: Obj = LocationInformationModel
+
+}
+
+object LocationInformation {
+  def apply(): LocationInformation = apply(Annotations())
+
+  def apply(annotations: Annotations): LocationInformation = new LocationInformation(Fields(), annotations)
+}

--- a/shared/src/main/scala/amf/core/internal/convert/CoreBaseConverter.scala
+++ b/shared/src/main/scala/amf/core/internal/convert/CoreBaseConverter.scala
@@ -56,7 +56,15 @@ import amf.core.client.platform.{config, model, transform, AMFResult => ClientAM
 import amf.core.client.scala.config._
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model._
-import amf.core.client.scala.model.document.{BaseUnit, BaseUnitProcessingData, Document, Module, PayloadFragment}
+import amf.core.client.scala.model.document.{
+  BaseUnit,
+  BaseUnitProcessingData,
+  BaseUnitSourceInformation,
+  LocationInformation,
+  Document,
+  Module,
+  PayloadFragment
+}
 import amf.core.client.scala.model.domain._
 import amf.core.client.scala.model.domain.extensions.{
   CustomDomainProperty,
@@ -124,7 +132,9 @@ trait CoreBaseConverter
     with ValidatePayloadRequestConverter
     with AmfObjectConverter
     with AmfObjectResultConverter
-    with BaseUnitProcessingDataConverter {
+    with BaseUnitProcessingDataConverter
+    with BaseUnitSourceInformationConverter
+    with LocationInformationConverter {
 
   implicit def asClient[Internal, Client](from: Internal)(
       implicit m: InternalClientMatcher[Internal, Client]): Client =
@@ -741,6 +751,28 @@ trait BaseUnitProcessingDataConverter extends PlatformSecrets {
       from._internal
 
     override def asClient(from: BaseUnitProcessingData): model.document.BaseUnitProcessingData =
+      platform.wrap(from)
+  }
+}
+
+trait BaseUnitSourceInformationConverter extends PlatformSecrets {
+  implicit object BaseUnitSourceInformationMatcher
+      extends BidirectionalMatcher[BaseUnitSourceInformation, model.document.BaseUnitSourceInformation] {
+    override def asInternal(from: model.document.BaseUnitSourceInformation): BaseUnitSourceInformation =
+      from._internal
+
+    override def asClient(from: BaseUnitSourceInformation): model.document.BaseUnitSourceInformation =
+      platform.wrap(from)
+  }
+}
+
+trait LocationInformationConverter extends PlatformSecrets {
+  implicit object LocationInformationMatcher
+      extends BidirectionalMatcher[LocationInformation, model.document.LocationInformation] {
+    override def asInternal(from: model.document.LocationInformation): LocationInformation =
+      from._internal
+
+    override def asClient(from: LocationInformation): model.document.LocationInformation =
       platform.wrap(from)
   }
 }

--- a/shared/src/main/scala/amf/core/internal/convert/CoreRegister.scala
+++ b/shared/src/main/scala/amf/core/internal/convert/CoreRegister.scala
@@ -3,7 +3,11 @@ package amf.core.internal.convert
 import amf.core.client.platform.model.document.{Document, ExternalFragment, Fragment, Module}
 import amf.core.client.platform.model.domain._
 import amf.core.internal.convert.CoreClientConverters._
-import amf.core.internal.metamodel.document.BaseUnitProcessingDataModel
+import amf.core.internal.metamodel.document.{
+  BaseUnitProcessingDataModel,
+  BaseUnitSourceInformationModel,
+  LocationInformationModel
+}
 import amf.core.internal.remote.Platform
 
 /** Shared Core registrations. */
@@ -65,6 +69,14 @@ object CoreRegister {
     platform.registerWrapper(BaseUnitProcessingDataModel) {
       case v: amf.core.client.scala.model.document.BaseUnitProcessingData =>
         new amf.core.client.platform.model.document.BaseUnitProcessingData(v)
+    }
+    platform.registerWrapper(BaseUnitSourceInformationModel) {
+      case v: amf.core.client.scala.model.document.BaseUnitSourceInformation =>
+        new amf.core.client.platform.model.document.BaseUnitSourceInformation(v)
+    }
+    platform.registerWrapper(LocationInformationModel) {
+      case v: amf.core.client.scala.model.document.LocationInformation =>
+        new amf.core.client.platform.model.document.LocationInformation(v)
     }
   }
 

--- a/shared/src/main/scala/amf/core/internal/entities/CoreEntities.scala
+++ b/shared/src/main/scala/amf/core/internal/entities/CoreEntities.scala
@@ -3,8 +3,10 @@ package amf.core.internal.entities
 import amf.core.internal.metamodel.{ModelDefaultBuilder, Obj}
 import amf.core.internal.metamodel.document.{
   BaseUnitProcessingDataModel,
+  BaseUnitSourceInformationModel,
   DocumentModel,
   ExternalFragmentModel,
+  LocationInformationModel,
   ModuleModel,
   SourceMapModel
 }
@@ -30,7 +32,9 @@ private[amf] object CoreEntities extends Entities {
       ExternalFragmentModel,
       ExternalDomainElementModel,
       DomainExtensionModel,
-      BaseUnitProcessingDataModel
+      BaseUnitProcessingDataModel,
+      BaseUnitSourceInformationModel,
+      LocationInformationModel
   )
 
 }

--- a/shared/src/main/scala/amf/core/internal/metamodel/document/BaseUnitModel.scala
+++ b/shared/src/main/scala/amf/core/internal/metamodel/document/BaseUnitModel.scala
@@ -76,6 +76,15 @@ trait BaseUnitModel extends ModelDefaultBuilder {
                  "Field with utility data to be used in Base Unit processing")
     )
 
+  val SourceInformation: Field =
+    Field(
+        BaseUnitSourceInformationModel,
+        Document + "sourceInformation",
+        ModelDoc(ModelVocabularies.AmlDoc,
+                 "sourceInformation",
+                 "Contains information of the source from which the base unit was generated")
+    )
+
 }
 
 object BaseUnitModel extends BaseUnitModel {
@@ -83,7 +92,8 @@ object BaseUnitModel extends BaseUnitModel {
   override val `type`: List[ValueType] = List(Document + "Unit")
 
   @silent("deprecated")
-  override val fields: List[Field] = List(ModelVersion, References, Usage, DescribedBy, Root, Package, ProcessingData)
+  override val fields: List[Field] =
+    List(ModelVersion, References, Usage, DescribedBy, Root, Package, ProcessingData, SourceInformation)
 
   override def modelInstance = throw new Exception("BaseUnit is an abstract class")
 

--- a/shared/src/main/scala/amf/core/internal/metamodel/document/BaseUnitSourceInformationModel.scala
+++ b/shared/src/main/scala/amf/core/internal/metamodel/document/BaseUnitSourceInformationModel.scala
@@ -1,0 +1,48 @@
+package amf.core.internal.metamodel.document
+
+import amf.core.client.scala.model.document.{BaseUnitSourceInformation, LocationInformation}
+import amf.core.client.scala.vocabulary.ValueType
+import amf.core.internal.metamodel.{Field, ModelDefaultBuilder}
+import amf.core.client.scala.vocabulary.Namespace.Document
+import amf.core.internal.metamodel.Type.{Array, Bool, Iri, Str}
+import amf.core.internal.metamodel.domain.{ModelDoc, ModelVocabularies}
+
+object BaseUnitSourceInformationModel extends ModelDefaultBuilder {
+
+  val RootLocation: Field = Field(
+      Str,
+      Document + "rootLocation",
+      ModelDoc(ModelVocabularies.AmlDoc, "rootLocation", "Root source location of base unit")
+  )
+
+  val AdditionalLocations: Field =
+    Field(
+        Array(LocationInformationModel),
+        Document + "additionalLocations",
+        ModelDoc(ModelVocabularies.AmlDoc,
+                 "additionalLocations",
+                 "Additional source locations from which certain elements where parsed")
+    )
+
+  override val `type`: List[ValueType] = List(Document + "BaseUnitSourceInformation")
+
+  override def modelInstance: BaseUnitSourceInformation = BaseUnitSourceInformation()
+
+  override def fields: List[Field] = List(RootLocation, AdditionalLocations)
+}
+
+object LocationInformationModel extends ModelDefaultBuilder {
+
+  val Elements: Field =
+    Field(
+        Array(Iri),
+        Document + "elements",
+        ModelDoc(ModelVocabularies.AmlDoc, "elements", "Elements which all belong to a certain source location")
+    )
+
+  override val `type`: List[ValueType] = List(Document + "LocationInformation")
+
+  override def modelInstance: LocationInformation = LocationInformation()
+
+  override def fields: List[Field] = List(BaseUnitModel.Location, Elements) // reusing location field from BaseUnit.
+}

--- a/shared/src/main/scala/amf/core/internal/metamodel/document/BaseUnitSourceInformationModel.scala
+++ b/shared/src/main/scala/amf/core/internal/metamodel/document/BaseUnitSourceInformationModel.scala
@@ -29,6 +29,11 @@ object BaseUnitSourceInformationModel extends ModelDefaultBuilder {
   override def modelInstance: BaseUnitSourceInformation = BaseUnitSourceInformation()
 
   override def fields: List[Field] = List(RootLocation, AdditionalLocations)
+
+  override val doc: ModelDoc = ModelDoc(
+      ModelVocabularies.AmlDoc,
+      "BaseUnitSourceInformation",
+      "Class that stores information of the source from which the base unit was parsed")
 }
 
 object LocationInformationModel extends ModelDefaultBuilder {
@@ -45,4 +50,9 @@ object LocationInformationModel extends ModelDefaultBuilder {
   override def modelInstance: LocationInformation = LocationInformation()
 
   override def fields: List[Field] = List(BaseUnitModel.Location, Elements) // reusing location field from BaseUnit.
+
+  override val doc: ModelDoc = ModelDoc(
+      ModelVocabularies.AmlDoc,
+      "LocationInformation",
+      "Class that store a specific location and the elements that where parsed from this source")
 }

--- a/shared/src/main/scala/amf/core/internal/parser/domain/SourceInformationGenerator.scala
+++ b/shared/src/main/scala/amf/core/internal/parser/domain/SourceInformationGenerator.scala
@@ -1,0 +1,36 @@
+package amf.core.internal.parser.domain
+
+import amf.core.client.scala.model.document.FieldsFilter.All
+import amf.core.client.scala.model.document.{BaseUnit, BaseUnitSourceInformation, LocationInformation}
+import amf.core.client.scala.model.domain.DomainElement
+import amf.core.internal.metamodel.document.BaseUnitSourceInformationModel
+
+object SourceInformationGenerator {
+
+  def generateSourceInformation(baseUnit: BaseUnit, rootLocation: String): Unit = {
+    val iterator = baseUnit.iterator(fieldsFilter = All).collect {
+      case element: DomainElement => element // TODO: use .filterType, requires making it compatible with Iterator
+    }
+    val locationToElements = iterator.foldLeft(Map.empty[String, List[String]]) {
+      case (result, element) =>
+        element.location() match {
+          case Some(elemLoc) if elemLoc != rootLocation =>
+            val newElements = result.get(elemLoc) match {
+              case Some(list) => element.id :: list
+              case None       => List(element.id)
+            }
+            result + (elemLoc -> newElements)
+          case _ => result
+        }
+    }
+    val result = BaseUnitSourceInformation().withRootLocation(rootLocation)
+    baseUnit.withSourceInformation(result) // set here so source info node is adopted. Not ideal.
+    val additionalLocations = locationToElements.zipWithIndex.map {
+      case ((loc, elements), i) =>
+        LocationInformation().withLocation(loc).withElements(elements).withId(result.id + s"/location_$i")
+    }
+    if (additionalLocations.nonEmpty)
+      result.setArrayWithoutId(BaseUnitSourceInformationModel.AdditionalLocations, additionalLocations.toList)
+  }
+
+}

--- a/shared/src/main/scala/amf/core/internal/plugins/document/graph/emitter/CommonEmitter.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/document/graph/emitter/CommonEmitter.scala
@@ -1,9 +1,12 @@
 package amf.core.internal.plugins.document.graph.emitter
 
+import amf.core.client.scala.config.RenderOptions
+import amf.core.client.scala.model.document.BaseUnit
 import amf.core.internal.annotations.{Declares, References}
 import amf.core.internal.metamodel.domain.ExternalSourceElementModel
 import amf.core.internal.metamodel.{Field, Obj}
 import amf.core.client.scala.model.domain.{AmfArray, AmfElement, AmfObject, ExternalSourceElement}
+import amf.core.internal.metamodel.document.BaseUnitModel
 import amf.core.internal.parser.domain.FieldEntry
 import amf.core.internal.parser.domain.{Annotations, FieldEntry}
 import amf.core.internal.plugins.document.graph.{JsonLdKeywords, MetaModelHelper}
@@ -38,12 +41,16 @@ trait CommonEmitter {
     }
   }
 
-  def getMetaModelFields(element: AmfObject, obj: Obj, extensionIris: Set[String]): Seq[Field] = {
+  def getMetaModelFields(element: AmfObject,
+                         obj: Obj,
+                         extensionIris: Set[String],
+                         renderOptions: RenderOptions): Seq[Field] = {
     val fields = MetaModelHelper.fieldsFrom(obj)
 
     val filteredFields = element match {
-      case e: ExternalSourceElement if e.isLinkToSource => fields.filter(f => f != ExternalSourceElementModel.Raw)
-      case _                                            => fields
+      case e: ExternalSourceElement if e.isLinkToSource    => fields.filter(f => f != ExternalSourceElementModel.Raw)
+      case _: BaseUnit if !renderOptions.sourceInformation => fields.filter(f => f != BaseUnitModel.SourceInformation)
+      case _                                               => fields
     }
 
     filteredFields ++ getExtensionFields(element, obj, extensionIris)

--- a/shared/src/main/scala/amf/core/internal/plugins/document/graph/emitter/EmbeddedJsonLdEmitter.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/document/graph/emitter/EmbeddedJsonLdEmitter.scala
@@ -116,7 +116,7 @@ private[amf] class EmbeddedJsonLdEmitter[T] private (val builder: DocBuilder[T],
   def traverseMetaModel(id: String, element: AmfObject, sources: SourceMap, obj: Obj, b: Entry[T]): Unit = {
     createTypeNode(b, obj)
 
-    val modelFields = getMetaModelFields(element, obj, Set.empty)
+    val modelFields = getMetaModelFields(element, obj, Set.empty, options)
 
     // no longer necessary?
     element match {


### PR DESCRIPTION
- Definition of new models:
SourceInformation(rootLocation: String, additionalLocations: Seq[LocationInformation]), stored in baseUnit.sourceInformation
LocationInformation(location: String, elements: Seq[String])
- Includes new render option withSourceInformation which renders SourceInformation node to jsonld, by default it is not activated.
- Generation of SourceInformation node is made after final id adoption.