### PR TITLE
APIMF-3311: fix ExternalSourceElement parsing from jsonld

### DIFF
--- a/shared/src/main/scala/amf/core/client/scala/model/document/Fragment.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/document/Fragment.scala
@@ -1,8 +1,7 @@
 package amf.core.client.scala.model.document
 
-import amf.core.internal.metamodel.Obj
-import amf.core.internal.metamodel.document.{DocumentModel, FragmentModel}
 import amf.core.client.scala.model.domain.{AmfObject, DomainElement}
+import amf.core.internal.metamodel.document.{DocumentModel, FragmentModel}
 
 /**
   * Fragments: Units encoding domain fragments

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/ExternalSourceElement.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/ExternalSourceElement.scala
@@ -1,9 +1,8 @@
 package amf.core.client.scala.model.domain
 
-import amf.core.internal.metamodel.Field
-import amf.core.internal.metamodel.domain.ExternalSourceElementModel._
 import amf.core.client.scala.model.StrField
 import amf.core.internal.adoption.AdoptionDependantCalls
+import amf.core.internal.metamodel.domain.ExternalSourceElementModel._
 
 trait ExternalSourceElement extends DomainElement with AdoptionDependantCalls {
 


### PR DESCRIPTION
fixes AMF issue [#1084](https://github.com/aml-org/amf/issues/1084)
