### PR TITLE
Proposal: stop having separate FileResourceLoader implementations per platform and rely on FileSystem instead.

### DIFF
--- a/js/src/main/scala/amf/core/internal/remote/server/JsServerFileResourceLoader.scala
+++ b/js/src/main/scala/amf/core/internal/remote/server/JsServerFileResourceLoader.scala
@@ -1,45 +1,30 @@
 package amf.core.internal.remote.server
 
-import java.io.IOException
-
 import amf.core.client.common.remote.Content
-import amf.core.client.platform.resource.BaseFileResourceLoader
-import amf.core.client.scala.lexer.CharSequenceStream
-import amf.core.internal.remote.FileMediaType._
-import amf.core.internal.remote.FileNotFound
-import org.mulesoft.common.io.Fs
+import amf.core.client.platform.resource.ResourceLoader
+import amf.core.client.scala.resource.{FileResourceLoader => InternalFileResourceLoader}
+import amf.core.internal.unsafe.PlatformSecrets
 
+import java.io.IOException
+import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
-import amf.core.internal.utils.AmfStrings
 
 @JSExportTopLevel("JsServerFileResourceLoader")
 @JSExportAll
-case class JsServerFileResourceLoader() extends BaseFileResourceLoader {
-  override def fetchFile(resource: String): js.Promise[Content] =
-    Fs.asyncFile(resource)
-      .read()
-      .map(
-          content =>
-            Content(new CharSequenceStream(resource, content),
-                    ensureFileAuthority(resource),
-                    extension(resource).flatMap(mimeFromExtension)))
-      .recoverWith {
-        case _: IOException => // exception for local file system where we accept resources including spaces
-          Fs.asyncFile(resource.urlDecoded)
-            .read()
-            .map(
-                content =>
-                  Content(new CharSequenceStream(resource, content),
-                          ensureFileAuthority(resource),
-                          extension(resource).flatMap(mimeFromExtension)))
-            .recover {
-              case io: IOException => throw FileNotFound(io)
-            }
-      }
-      .toJSPromise
+case class JsServerFileResourceLoader() extends ResourceLoader with PlatformSecrets {
 
-  def ensureFileAuthority(str: String): String = if (str.startsWith("file:")) str else s"file://$str"
+  private val internal =
+    InternalFileResourceLoader(platform.fs, e => e.isInstanceOf[IOException])(ExecutionContext.global)
+
+  /** Fetch specified resource and return associated content. Resource should have been previously accepted.
+    * If the resource doesn't exists, it returns a failed future caused by a ResourceNotFound exception. */
+  override def fetch(resource: String): js.Promise[Content] = {
+    internal.fetch(resource).toJSPromise
+  }
+
+  /** Checks if the resource loader accepts the specified resource. */
+  override def accepts(resource: String): Boolean = internal.accepts(resource)
 }

--- a/jvm/src/main/scala/amf/core/client/platform/resource/FileResourceLoader.scala
+++ b/jvm/src/main/scala/amf/core/client/platform/resource/FileResourceLoader.scala
@@ -1,50 +1,30 @@
 package amf.core.client.platform.resource
 
+import amf.core.client.common.remote.Content
+import amf.core.client.platform.execution.BaseExecutionEnvironment
+import amf.core.client.scala.resource.{FileResourceLoader => InternalFileResourceLoader}
+import amf.core.internal.remote.FileNotFound
+import amf.core.internal.remote.FutureConverter._
+import amf.core.internal.unsafe.PlatformSecrets
+
 import java.io.FileNotFoundException
 import java.util.concurrent.CompletableFuture
-import amf.core.client.platform.execution.BaseExecutionEnvironment
-import amf.core.client.common.remote.Content
-import amf.core.client.scala.lexer.FileStream
-import amf.core.internal.remote.FileMediaType._
-import amf.core.internal.remote.FutureConverter._
-import amf.core.internal.remote.{FileNotFound, JvmPlatform}
-import amf.core.internal.utils.AmfStrings
-
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 case class FileResourceLoader(executionContext: ExecutionContext)
-    extends BaseFileResourceLoader
+    extends ResourceLoader
+    with PlatformSecrets
     with LoaderWithExecutionContext {
 
   implicit val exec: ExecutionContext = executionContext
+  private val internal                = InternalFileResourceLoader(platform.fs, e => e.isInstanceOf[FileNotFoundException])
 
   def this() = this(scala.concurrent.ExecutionContext.Implicits.global)
   def this(executionEnvironment: BaseExecutionEnvironment) = this(executionEnvironment.executionContext)
 
+  override def fetch(resource: String): CompletableFuture[Content] = internal.fetch(resource).asJava
+
+  override def accepts(resource: String): Boolean = internal.accepts(resource)
+
   override def withExecutionContext(newEc: ExecutionContext): ResourceLoader = FileResourceLoader(newEc)
-
-  def baseFetchFile(base: String) = {
-    val resource = base.replace("file://","/")
-    try {
-      Content(new FileStream(resource),
-        ensureFileAuthority(resource),
-        extension(resource).flatMap(mimeFromExtension))
-    } catch {
-      case e: FileNotFoundException =>
-        // exception for local file system where we accept spaces [] and other chars in files names
-        val decoded = resource.urlDecoded
-        try {
-          Content(new FileStream(decoded),
-            ensureFileAuthority(resource),
-            extension(resource).flatMap(mimeFromExtension))
-        } catch {
-          case e: FileNotFoundException => throw FileNotFound(e)
-        }
-    }
-  }
-  def fetchFile(resource: String): CompletableFuture[Content] = {
-    Future(baseFetchFile(resource)).asJava
-  }
-
-  def ensureFileAuthority(str: String): String = if (str.startsWith("file:")) str else s"file://$str"
 }

--- a/shared/src/main/scala/amf/core/client/scala/resource/FileResourceLoader.scala
+++ b/shared/src/main/scala/amf/core/client/scala/resource/FileResourceLoader.scala
@@ -1,0 +1,56 @@
+package amf.core.client.scala.resource
+
+import amf.core.client.common.remote.Content
+import amf.core.client.scala.lexer.{CharSequenceStream, CharStream}
+import amf.core.client.scala.resource.FileResourceLoader.defaultCatch
+import amf.core.internal.remote.File.FILE_PROTOCOL
+import amf.core.internal.remote.FileMediaType.{extension, mimeFromExtension}
+import amf.core.internal.remote.{File, FileNotFound}
+import amf.core.internal.utils.AmfStrings
+import org.mulesoft.common.io.FileSystem
+
+import java.io.{FileNotFoundException, IOException}
+import scala.concurrent.{ExecutionContext, Future}
+
+object FileResourceLoader {
+  protected val defaultCatch: Throwable => Boolean = {
+    case _: IOException => true
+  }
+}
+
+case class FileResourceLoader(private val fs: FileSystem,
+                              private val shouldCatch: Throwable => Boolean = defaultCatch)(
+    private implicit val executionContext: ExecutionContext)
+    extends ResourceLoader {
+
+  override def fetch(resource: String): Future[Content] = fetchFile(resource.stripPrefix(FILE_PROTOCOL))
+
+  override def accepts(resource: String): Boolean = resource match {
+    case File(_) => true
+    case _       => false
+  }
+
+  private def fetchFile(resource: String): Future[Content] = {
+    buildContent(resource)
+      .recoverWith {
+        case e: Throwable if shouldCatch(e) => buildContent(resource.urlDecoded, resource)
+      }
+      .recover {
+        case e: Throwable if shouldCatch(e) => throw FileNotFound(e)
+      }
+  }
+
+  private def buildContent(resource: String): Future[Content] = buildContent(resource, resource)
+
+  private def buildContent(resource: String, originalResource: String): Future[Content] = {
+    readFileContents(resource).map { content =>
+      Content(new CharSequenceStream(originalResource, content),
+              ensureFileURIScheme(originalResource),
+              extension(originalResource).flatMap(mimeFromExtension))
+    }
+  }
+
+  private def readFileContents(resource: String): Future[String] = fs.asyncFile(resource).read().map(_.toString)
+
+  private def ensureFileURIScheme(str: String): String = if (str.startsWith("file:")) str else s"file://$str"
+}


### PR DESCRIPTION
**Objective**: have a way to unit-test the adapter logic inside the ResourceLoader implementations from a "shared" scala test suite.
- This is also helpful to mock the "FileSystem" object and "spy" on the end products of AMF's uri-resolution mechanism. This is especially useful when debugging APIKIT Api Sync error cases.

**Concerns**
- The only concern I have is regarding performance between the JvmFileSystem implementations and the legacy file reading mechanism. Unfortunately I don't see a way to easily benchmark this as disk I/O will affect the measurement a lot.

**Note**: this small refactor is made to be fully backwards compatible with the previous implementation.