### PR TITLE
APIMF-3517: unify resolvePath platform differences + refactor Platform methods

### DIFF
--- a/js/src/main/scala/amf/core/internal/remote/JsPlatform.scala
+++ b/js/src/main/scala/amf/core/internal/remote/JsPlatform.scala
@@ -25,7 +25,4 @@ trait JsPlatform extends Platform {
   /** decodes a uri component */
   override def decodeURIComponent(url: String): String = URIUtils.decodeURIComponent(url)
 
-  override def normalizeURL(url: String): String = Path.normalize(url)
-
-  override def normalizePath(url: String): String = fixFilePrefix(new URI(encodeURI(url)).normalize.toString)
 }

--- a/js/src/main/scala/amf/core/internal/remote/browser/JsBrowserPlatform.scala
+++ b/js/src/main/scala/amf/core/internal/remote/browser/JsBrowserPlatform.scala
@@ -29,8 +29,6 @@ class JsBrowserPlatform extends JsPlatform {
 
   override def operativeSystem(): String = "web"
 
-  override def resolvePath(path: String): String = path
-
 }
 
 @JSExportAll

--- a/js/src/main/scala/amf/core/internal/remote/server/JsServerPlatform.scala
+++ b/js/src/main/scala/amf/core/internal/remote/server/JsServerPlatform.scala
@@ -32,17 +32,6 @@ class JsServerPlatform extends JsPlatform {
   /** Return temporary directory. */
   override def tmpdir(): String = OS.tmpdir() + "/"
 
-  override def resolvePath(uri: String): String = {
-    uri match {
-      case File(path) if fs.separatorChar == '/' => FILE_PROTOCOL + normalizeURL(path)
-      case File(path)                            => FILE_PROTOCOL + normalizeURL(path).replace(fs.separatorChar.toString, "/")
-      case HttpParts(protocol, host, path)       => protocol + host + normalizePath(withTrailingSlash(path))
-      case _                                     => uri
-    }
-  }
-
-  private def withTrailingSlash(path: String) = (if (!path.startsWith("/")) "/" else "") + path
-
   /** Return the OS (win, mac, nux). */
   override def operativeSystem(): String = {
     OS.platform() match {

--- a/jvm/src/main/scala/amf/core/internal/remote/JvmPlatform.scala
+++ b/jvm/src/main/scala/amf/core/internal/remote/JvmPlatform.scala
@@ -30,11 +30,6 @@ class JvmPlatform extends Platform {
   /** Location where the helper functions for custom validations must be retrieved */
   override def customValidationLibraryHelperLocation: String = "classpath:validations/amf_validation.js"
 
-  override def resolvePath(path: String): String = {
-    val res = new URI(path).normalize.toString
-    fixFilePrefix(res)
-  }
-
   override def findCharInCharSequence(stream: CharSequence)(p: Char => Boolean): Option[Char] = {
     stream.chars().filter(c => p(c.toChar)).findFirst() match {
       case optInt if optInt.isPresent => Some(optInt.getAsInt.toChar)
@@ -54,11 +49,7 @@ class JvmPlatform extends Platform {
   /** decodes a URI component */
   override def decodeURIComponent(url: String): String = EcmaEncoder.decode(url, fullUri = false)
 
-  override def normalizeURL(url: String): String = encodeURI(url)
-
   private def replaceWhiteSpaces(url: String) = url.replaceAll(" ", "%20")
-
-  override def normalizePath(url: String): String = fixFilePrefix(new URI(encodeURI(url)).normalize.toString)
 
   /** Return the OS (win, mac, nux). */
   override def operativeSystem(): String = {

--- a/shared/src/main/scala/amf/core/client/scala/parse/AMFParser.scala
+++ b/shared/src/main/scala/amf/core/client/scala/parse/AMFParser.scala
@@ -3,9 +3,16 @@ package amf.core.client.scala.parse
 import amf.core.client.scala.resource.ResourceLoader
 import amf.core.client.scala.{AMFGraphConfiguration, AMFObjectResult, AMFParseResult, AMFResult}
 import amf.core.internal.convert.CoreClientConverters.platform
-import amf.core.internal.parser.{AMFCompiler, AMFGraphPartialCompiler, AmfObjectUnitContainer, CompilerConfiguration, CompilerContextBuilder}
+import amf.core.internal.parser.{
+  AMFCompiler,
+  AMFGraphPartialCompiler,
+  AmfObjectUnitContainer,
+  CompilerConfiguration,
+  CompilerContextBuilder
+}
 import amf.core.internal.remote.{Cache, Context}
 import amf.core.internal.resource.StringResourceLoader
+import amf.core.internal.utils.UriUtils
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -85,7 +92,7 @@ object AMFParser {
   }
 
   private def fromStream(url: String, stream: String, mediaType: Option[String]): ResourceLoader =
-    StringResourceLoader(platform.resolvePath(url), stream, mediaType)
+    StringResourceLoader(UriUtils.resolvePath(url), stream, mediaType)
 
   private[amf] val DEFAULT_DOCUMENT_URL = "http://a.ml/amf/default_document"
 }

--- a/shared/src/main/scala/amf/core/internal/parser/CompilerContext.scala
+++ b/shared/src/main/scala/amf/core/internal/parser/CompilerContext.scala
@@ -4,7 +4,7 @@ import amf.core.client.common.remote.Content
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.parse.document.ParserContext
 import amf.core.internal.remote.{Cache, Context, Platform, Spec}
-import amf.core.internal.utils.AmfStrings
+import amf.core.internal.utils.{AmfStrings, UriUtils}
 import amf.core.internal.validation.core.ValidationSpecification
 import org.mulesoft.lexer.SourceLocation
 
@@ -31,7 +31,7 @@ class CompilerContext(val url: String,
 
   lazy val platform: Platform = fileContext.platform
 
-  def resolvePath(url: String): String = fileContext.resolve(fileContext.platform.normalizePath(url))
+  def resolvePath(url: String): String = fileContext.resolve(UriUtils.normalizePath(url))
 
   def fetchContent(): Future[Content] = compilerConfig.resolveContent(location)
 

--- a/shared/src/main/scala/amf/core/internal/remote/Context.scala
+++ b/shared/src/main/scala/amf/core/internal/remote/Context.scala
@@ -5,8 +5,7 @@ import amf.core.internal.utils.{Absolute, RelativeToIncludedFile, RelativeToRoot
 /**
   * Context class for URL resolution.
   */
-class Context protected(val platform: Platform,
-                        val history: List[String]) {
+class Context protected (val platform: Platform, val history: List[String]) {
 
   def hasCycles: Boolean = history.count(_.equals(current)) == 2
 
@@ -28,15 +27,13 @@ class Context protected(val platform: Platform,
       case RelativeToRoot(_)         => Some(root)
       case RelativeToIncludedFile(_) => Some(current)
     }
-    UriUtils.resolve(base, url)
+    UriUtils.resolveWithBase(base, url)
   }
 
 }
 
 object Context {
-  private def apply(platform: Platform,
-                    history: List[String],
-                    currentResolved: String): Context =
+  private def apply(platform: Platform, history: List[String], currentResolved: String): Context =
     new Context(platform, history :+ currentResolved)
 
   def apply(platform: Platform): Context = new Context(platform, Nil)

--- a/shared/src/main/scala/amf/core/internal/remote/Platform.scala
+++ b/shared/src/main/scala/amf/core/internal/remote/Platform.scala
@@ -114,16 +114,6 @@ trait Platform extends FileMediaType {
   /** Platform out of the box [ResourceLoader]s */
   def loaders()(implicit executionContext: ExecutionContext): Seq[ResourceLoader]
 
-  def ensureFileAuthority(str: String): String =
-    if (str.startsWith("file:")) {
-      str
-    } else {
-      s"file://$str"
-    }
-
-  /** Test path resolution. */
-  def resolvePath(path: String): String
-
   /** encodes a complete uri. Not encodes chars like / */
   def encodeURI(url: String): String
 
@@ -143,12 +133,6 @@ trait Platform extends FileMediaType {
     } catch {
       case _: Throwable => Left(url)
     }
-
-  /** validates and normalize complete url */
-  def normalizeURL(url: String): String
-
-  /** normalize path method for file fetching in amf compiler */
-  def normalizePath(url: String): String
 
   /** Location where the helper functions for custom validations must be retrieved */
   protected def customValidationLibraryHelperLocation: String = "http://a.ml/amf/validation.js"
@@ -171,15 +155,6 @@ trait Platform extends FileMediaType {
   protected def writeFile(path: String, content: String)(implicit executionContext: ExecutionContext): Future[Unit] =
     fs.asyncFile(path).write(content)
 
-  protected def fixFilePrefix(res: String): String = {
-    if (res.startsWith("file://") || res.startsWith("file:///")) {
-      res
-    } else if (res.startsWith("file:/")) {
-      res.replace("file:/", "file:///")
-    } else {
-      res
-    }
-  }
 }
 
 object Platform {

--- a/shared/src/main/scala/amf/core/internal/unsafe/PlatformSecrets.scala
+++ b/shared/src/main/scala/amf/core/internal/unsafe/PlatformSecrets.scala
@@ -20,9 +20,6 @@ case class TrunkPlatform(content: String,
   /** Underlying file system for platform. */
   override val fs: FileSystem = UnsupportedFileSystem
 
-  /** Test path resolution. */
-  override def resolvePath(path: String): String = path
-
   override def tmpdir(): String = throw new Exception("Unsupported tmpdir operation")
 
   override def fetchContent(url: String, configuration: AMFGraphConfiguration)(
@@ -47,10 +44,6 @@ case class TrunkPlatform(content: String,
 
   /** decodes a uri component */
   override def decodeURIComponent(url: String): String = url
-
-  override def normalizeURL(url: String): String = url
-
-  override def normalizePath(url: String): String = url
 
   /** Return the OS (win, mac, nux). */
   override def operativeSystem(): String = "trunk"

--- a/shared/src/main/scala/amf/core/internal/utils/package.scala
+++ b/shared/src/main/scala/amf/core/internal/utils/package.scala
@@ -50,7 +50,7 @@ package object utils {
     def noSpaces: String = str.replace(" ", "")
 
     /** normalize and check that the string its a valid URI */
-    def normalizePath: String = platform.normalizePath(str)
+    def normalizePath: String = UriUtils.normalizePath(str)
 
     /** Url encoded string. */
     def urlComponentEncoded: String = platform.encodeURIComponent(str)

--- a/shared/src/test/scala/amf/core/internal/remote/PlatformTest.scala
+++ b/shared/src/test/scala/amf/core/internal/remote/PlatformTest.scala
@@ -52,15 +52,6 @@ class PlatformTest extends AsyncFunSuite with Matchers with ListAssertions with 
       })
   }
 
-  test("Path resolution") {
-    Future.successful({
-      val url = "file://shared/src/test/resources/input.yaml"
-
-      platform.resolvePath(url) should be(url)
-      platform.resolvePath("file://shared/src/test/resources/ignored/../input.yaml") should be(url)
-    })
-  }
-
   ignore("Write") {
     val path = "file:///tmp/" + new Date().getTime
     platform.write(path, "{\n\"name\" : \"Jason Bourne\"\n}").map[Assertion](unit => path should not be null)

--- a/shared/src/test/scala/amf/core/internal/utils/UtilsTest.scala
+++ b/shared/src/test/scala/amf/core/internal/utils/UtilsTest.scala
@@ -15,7 +15,8 @@ class UtilsTest extends AnyFunSuite with Matchers {
     ResolveUrl("file://some/dir/api.raml", "http://some.example/")    -> "http://some.example/",
     ResolveUrl("file://some/dir/api.raml", "#/some/fragment")         -> "file://some/dir/api.raml#/some/fragment",
     ResolveUrl("file://dir/other/directory/", "../file.json")         -> "file://dir/other/file.json",
-    ResolveUrl("file://dir/other/directory/file.json", "")            -> "file://dir/other/directory/"
+    ResolveUrl("file://dir/other/directory/file.json", "")            -> "file://dir/other/directory/",
+    ResolveUrl("file:///", "../file.json")                             -> "file:///../file.json",
   )
 
   resolveTests.foreach {
@@ -24,6 +25,20 @@ class UtilsTest extends AnyFunSuite with Matchers {
       val result                = UriUtils.resolveRelativeTo(base, url)
       test(s"Resolved uri $expected") {
         result should be(expected)
+      }
+  }
+
+  val urlResolveTests: List[(String, String)] = List(
+    "file://resources/input.yaml"            -> "file://resources/input.yaml",
+    "file://resources/ignored/../input.yaml" -> "file://resources/input.yaml",
+    "file://../dataType.yaml"                -> "file://../dataType.yaml",
+    "file:///../dataType.yaml"                -> "file:///../dataType.yaml",
+  )
+
+  urlResolveTests.foreach {
+    case (input, output) =>
+      test(s" the url $input should be resolved to $output") {
+        UriUtils.resolvePath(input) should be(output)
       }
   }
 


### PR DESCRIPTION
### Problem
Resolution of path which traverses outside of root directory is incorrect in JsServerPlatform implementation:
- JvmPlatform: resolvePath(`"file:///../../dataType.raml"`) -> `"file:///../../dataType.raml"`
- JsServerPlatform: resolvePath(`"file:///../../dataType.raml"`) -> `"file:///dataType.raml"`

### Solution
**Actual changes:**
resolvePath implementation was unified using JvmPlatform's implementation, scala.js has support for java.net.URI.

**Refactors:**
- normalizePath was removed from Platform interface as both implementations where identical.
- unused methods where removed (normalizeURL, ensureFileAuthority)

Platform is left with no path normalization functionality, except for encoding/decoding which does depend on platform specific implementations. Path normalization functionality is grouped under UriUtils object.