### PR TITLE
APIMF-3676: define new constructor for Content where url is not required

### DIFF
--- a/shared/src/main/scala/amf/core/client/common/remote/Content.scala
+++ b/shared/src/main/scala/amf/core/client/common/remote/Content.scala
@@ -4,15 +4,28 @@ import amf.core.client.scala.lexer.{CharSequenceStream, CharStream}
 
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 
-case class Content(stream: CharStream, url: String, mime: Option[String] = None) {
+case class Content(stream: CharStream, url: Option[String], mime: Option[String] = None) {
 
   @JSExportTopLevel("Content")
-  def this(stream: String, url: String) = this(new CharSequenceStream(url, stream), url)
+  def this(stream: String) = this(new CharSequenceStream("", stream), None)
 
   @JSExportTopLevel("Content")
-  def this(stream: String, url: String, mime: String) = this(new CharSequenceStream(url, stream), url, Some(mime))
+  def this(stream: String, url: String) = this(new CharSequenceStream(url, stream), Some(url))
 
-  def this(stream: String, url: String, mime: Option[String]) = this(new CharSequenceStream(url, stream), url, mime)
+  @JSExportTopLevel("Content")
+  def this(stream: String, url: String, mime: String) =
+    this(new CharSequenceStream(url, stream), Some(url), Some(mime))
+
+  def this(stream: String, url: String, mime: Option[String]) =
+    this(new CharSequenceStream(url, stream), Some(url), mime)
+
+  def this(stream: CharStream, url: String) = this(stream, Some(url), None)
+  def this(stream: CharStream, url: String, mime: Option[String]) = this(stream, Some(url), mime)
 
   override def toString: String = stream.toString
+}
+
+object Content {
+  def apply(stream: CharStream, url: String)                       = new Content(stream, Some(url), None)
+  def apply(stream: CharStream, url: String, mime: Option[String]) = new Content(stream, Some(url), mime)
 }

--- a/shared/src/main/scala/amf/core/client/scala/validation/payload/ShapeValidationConfiguration.scala
+++ b/shared/src/main/scala/amf/core/client/scala/validation/payload/ShapeValidationConfiguration.scala
@@ -3,6 +3,8 @@ package amf.core.client.scala.validation.payload
 import amf.core.client.common.remote.Content
 import amf.core.client.scala.AMFGraphConfiguration
 import amf.core.client.scala.errorhandling.AMFErrorHandler
+import amf.core.internal.remote.InternalContent
+import amf.core.internal.convert.CoreClientConverters._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -16,5 +18,6 @@ case class ShapeValidationConfiguration(private[amf] val config: AMFGraphConfigu
   val maxYamlReferences: Option[Int]     = config.options.parsingOptions.maxYamlReferences
 
   // Necessary for Java XML Payload Validator
-  def fetchContent(url: String): Future[Content] = config.resolvers.resolveContent(url)
+  def fetchContent(url: String): Future[Content] =
+    config.resolvers.resolveContent(url).map(InternalContentMatcher.asClient(_))(config.getExecutionContext)
 }

--- a/shared/src/main/scala/amf/core/internal/convert/CoreBaseConverter.scala
+++ b/shared/src/main/scala/amf/core/internal/convert/CoreBaseConverter.scala
@@ -60,8 +60,8 @@ import amf.core.client.scala.model.document.{
   BaseUnit,
   BaseUnitProcessingData,
   BaseUnitSourceInformation,
-  LocationInformation,
   Document,
+  LocationInformation,
   Module,
   PayloadFragment
 }
@@ -85,7 +85,7 @@ import amf.core.client.scala.{AMFGraphConfiguration, AMFObjectResult, AMFParseRe
 import amf.core.internal.convert.PayloadValidatorConverter.PayloadValidatorMatcher
 import amf.core.internal.parser.domain.Annotations
 import amf.core.internal.reference.UnitCacheAdapter
-import amf.core.internal.remote.Spec
+import amf.core.internal.remote.{InternalContent, Spec}
 import amf.core.internal.resource.{ClientResourceLoaderAdapter, InternalResourceLoaderAdapter}
 import amf.core.internal.unsafe.PlatformSecrets
 import amf.core.internal.validation.{ValidationCandidate, ValidationShapeSet}
@@ -134,7 +134,8 @@ trait CoreBaseConverter
     with AmfObjectResultConverter
     with BaseUnitProcessingDataConverter
     with BaseUnitSourceInformationConverter
-    with LocationInformationConverter {
+    with LocationInformationConverter
+    with ContentConverter {
 
   implicit def asClient[Internal, Client](from: Internal)(
       implicit m: InternalClientMatcher[Internal, Client]): Client =
@@ -774,5 +775,11 @@ trait LocationInformationConverter extends PlatformSecrets {
 
     override def asClient(from: LocationInformation): model.document.LocationInformation =
       platform.wrap(from)
+  }
+}
+
+trait ContentConverter extends PlatformSecrets {
+  implicit object InternalContentMatcher extends InternalClientMatcher[InternalContent, Content] {
+    override def asClient(from: InternalContent): Content = Content(from.stream, Some(from.url), from.mime)
   }
 }

--- a/shared/src/main/scala/amf/core/internal/parser/CompilerConfiguration.scala
+++ b/shared/src/main/scala/amf/core/internal/parser/CompilerConfiguration.scala
@@ -5,6 +5,7 @@ import amf.core.client.scala.AMFGraphConfiguration
 import amf.core.client.scala.config.{AMFEvent, UnitCache}
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.parse.{AMFParsePlugin, AMFSyntaxParsePlugin}
+import amf.core.internal.remote.InternalContent
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -15,8 +16,8 @@ case class CompilerConfiguration(private val config: AMFGraphConfiguration) {
 
   val eh: AMFErrorHandler = config.errorHandlerProvider.errorHandler()
 
-  val executionContext: ExecutionContext           = config.resolvers.executionEnv.context
-  def resolveContent(url: String): Future[Content] = config.resolvers.resolveContent(url)
+  val executionContext: ExecutionContext                   = config.resolvers.executionEnv.context
+  def resolveContent(url: String): Future[InternalContent] = config.resolvers.resolveContent(url)
 
   val rootSortedParsePlugins: Seq[AMFParsePlugin] = config.registry.getPluginsRegistry.rootParsePlugins.sorted
   lazy val referenceSortedParsePlugins: Seq[AMFParsePlugin] =

--- a/shared/src/main/scala/amf/core/internal/parser/CompilerContext.scala
+++ b/shared/src/main/scala/amf/core/internal/parser/CompilerContext.scala
@@ -3,7 +3,7 @@ package amf.core.internal.parser
 import amf.core.client.common.remote.Content
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.parse.document.ParserContext
-import amf.core.internal.remote.{Cache, Context, Platform, Spec}
+import amf.core.internal.remote.{Cache, Context, InternalContent, Platform, Spec}
 import amf.core.internal.utils.{AmfStrings, UriUtils}
 import amf.core.internal.validation.core.ValidationSpecification
 import org.mulesoft.lexer.SourceLocation
@@ -33,7 +33,7 @@ class CompilerContext(val url: String,
 
   def resolvePath(url: String): String = fileContext.resolve(UriUtils.normalizePath(url))
 
-  def fetchContent(): Future[Content] = compilerConfig.resolveContent(location)
+  def fetchContent(): Future[InternalContent] = compilerConfig.resolveContent(location)
 
   def forReference(refUrl: String, allowedSpecs: Seq[Spec] = Seq.empty)(
       implicit executionContext: ExecutionContext): CompilerContext = {

--- a/shared/src/main/scala/amf/core/internal/remote/InternalContent.scala
+++ b/shared/src/main/scala/amf/core/internal/remote/InternalContent.scala
@@ -1,0 +1,19 @@
+package amf.core.internal.remote
+
+import amf.core.client.common.remote.Content
+import amf.core.client.scala.lexer.CharStream
+
+/**
+  *
+  */
+case class InternalContent(stream: CharStream, url: String, mime: Option[String] = None)
+
+object InternalContent {
+
+  /**
+    * ClientContent may not define a url, for this case a default url is defined.
+    */
+  def withUrl(content: Content, defaultUrl: String): InternalContent = {
+    InternalContent(content.stream, content.url.getOrElse(defaultUrl), content.mime)
+  }
+}

--- a/shared/src/main/scala/amf/core/internal/resource/AMFResolvers.scala
+++ b/shared/src/main/scala/amf/core/internal/resource/AMFResolvers.scala
@@ -5,7 +5,7 @@ import amf.core.client.platform.resource.{LoaderWithExecutionContext => Platform
 import amf.core.client.scala.config.UnitCache
 import amf.core.client.scala.execution.ExecutionEnvironment
 import amf.core.client.scala.resource.{LoaderWithExecutionContext, ResourceLoader}
-import amf.core.internal.remote.UnsupportedUrlScheme
+import amf.core.internal.remote.{InternalContent, UnsupportedUrlScheme}
 import amf.core.internal.unsafe.PlatformSecrets
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -74,8 +74,10 @@ private[amf] case class AMFResolvers(resourceLoaders: List[ResourceLoader],
     * @param executionContext
     * @return
     */
-  def resolveContent(url: String): Future[Content] = {
-    loaderConcat(url, resourceLoaders.filter(_.accepts(url)))(executionEnv.context)
+  def resolveContent(url: String): Future[InternalContent] = {
+    implicit val context: ExecutionContext = executionEnv.context
+    val clientContent                      = loaderConcat(url, resourceLoaders.filter(_.accepts(url)))
+    clientContent.map(InternalContent.withUrl(_, url))
   }
 
   private def loaderConcat(url: String, loaders: Seq[ResourceLoader])(

--- a/shared/src/test/scala/amf/core/internal/remote/PlatformTest.scala
+++ b/shared/src/test/scala/amf/core/internal/remote/PlatformTest.scala
@@ -18,7 +18,7 @@ class PlatformTest extends AsyncFunSuite with Matchers with ListAssertions with 
 
   test("File") {
     AMFResolvers.predefined().resolveContent("file://shared/src/test/resources/input.yaml") map {
-      case Content(content, _, mime) =>
+      case InternalContent(content, _, mime) =>
         mime should contain(`application/yaml`)
 
         content.toString should be

--- a/shared/src/test/scala/amf/core/parser/CompilerConfigTest.scala
+++ b/shared/src/test/scala/amf/core/parser/CompilerConfigTest.scala
@@ -1,0 +1,46 @@
+package amf.core.parser
+
+import amf.core.client.common.remote.Content
+import amf.core.client.scala.AMFGraphConfiguration
+import amf.core.client.scala.parse.document.SyamlParsedDocument
+import amf.core.client.scala.resource.ResourceLoader
+import amf.core.internal.parser.{AMFCompiler, CompilerConfiguration, CompilerContextBuilder}
+import amf.core.internal.remote.InternalContent
+import amf.core.internal.unsafe.PlatformSecrets
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class CompilerConfigTest() extends AsyncFunSuite with PlatformSecrets with Matchers {
+
+  override implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  class CustomContentUrlResourceLoader(customUrl: Option[String]) extends ResourceLoader {
+    override def fetch(resource: String): Future[Content] = Future.successful(
+        customUrl match {
+          case Some(defined) => new Content("with custom url".stripMargin, defined)
+          case None          => new Content("without url") // new constructor where no url has to be passed.
+        }
+    )
+    override def accepts(resource: String): Boolean = true
+  }
+
+  test("fetch content with resource loader that returns custom url") {
+    val url          = "file://some/url.json"
+    val customUrl    = "file://some/other/url.json"
+    val customLoader = new CustomContentUrlResourceLoader(Some(customUrl))
+    obtainContentFromConfig(url, customLoader).map(_.url shouldBe customUrl)
+  }
+
+  test("fetch content with resource loader that returns no url") {
+    val url          = "file://some/url.json"
+    val customLoader = new CustomContentUrlResourceLoader(None)
+    obtainContentFromConfig(url, customLoader).map(_.url shouldBe url)
+  }
+
+  def obtainContentFromConfig(url: String, rl: ResourceLoader): Future[InternalContent] = {
+    val config = AMFGraphConfiguration.predefined().withResourceLoaders(List(rl))
+    CompilerConfiguration(config).resolveContent(url)
+  }
+}


### PR DESCRIPTION
**Change**: New Constructor is defined in Content that only receives the content and no url. 
**Implications**: This forces the underlying case class to define the `url` as optional, which _could_ be considered a breaking change. The `url` attribute of Content is not exported in JS, but can be accessed in java/scala.