### PR TITLE
W-10547462: added @context override for parsing

### DIFF
--- a/shared/src/main/scala/amf/core/client/scala/AMFGraphConfiguration.scala
+++ b/shared/src/main/scala/amf/core/client/scala/AMFGraphConfiguration.scala
@@ -56,7 +56,7 @@ object AMFGraphConfiguration {
           .withAnnotations(CoreSerializableAnnotations.annotations),
         Set.empty,
         AMFOptions.default()
-    ).withPlugins(List(AMFGraphParsePlugin, AMFGraphRenderPlugin, SyamlSyntaxParsePlugin, SyamlSyntaxRenderPlugin))
+    ).withPlugins(List(AMFGraphParsePlugin(), AMFGraphRenderPlugin, SyamlSyntaxParsePlugin, SyamlSyntaxRenderPlugin))
       .withTransformationPipeline(BasicTransformationPipeline())
   }
 

--- a/shared/src/main/scala/amf/core/client/scala/config/ParsingOptions.scala
+++ b/shared/src/main/scala/amf/core/client/scala/config/ParsingOptions.scala
@@ -25,5 +25,4 @@ case class ParsingOptions(amfJsonLdSerialization: Boolean = true,
   def isAmfJsonLdSerialization: Boolean = amfJsonLdSerialization
   def definedBaseUrl: Option[String]    = baseUnitUrl
   def getMaxYamlReferences: Option[Int] = maxYamlReferences
-
 }

--- a/shared/src/main/scala/amf/core/internal/plugins/document/graph/parser/GraphParserContext.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/document/graph/parser/GraphParserContext.scala
@@ -18,4 +18,12 @@ class GraphParserContext(rootContextDocument: String = "",
                          futureDeclarations: FutureDeclarations = EmptyFutureDeclarations(),
                          config: ParseConfiguration,
                          val graphContext: GraphContext = GraphContext())
-    extends SyamlBasedParserErrorHandler(rootContextDocument, refs, futureDeclarations, config) {}
+    extends SyamlBasedParserErrorHandler(rootContextDocument, refs, futureDeclarations, config) {
+
+  def addTerms(aliases: Map[String, String]): this.type = {
+    aliases.foreach {
+      case (term, id) => graphContext.withTerm(term, id)
+    }
+    this
+  }
+}

--- a/shared/src/main/scala/amf/core/internal/plugins/parse/AMFGraphParsePlugin.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/parse/AMFGraphParsePlugin.scala
@@ -16,13 +16,13 @@ import amf.core.internal.plugins.document.graph.parser.{
 import amf.core.internal.remote.Spec.AMF
 import amf.core.internal.remote.{Mimes, Spec}
 
-object AMFGraphParsePlugin extends AMFParsePlugin {
+case class AMFGraphParsePlugin(private val aliases: Map[String, String] = Map.empty) extends AMFParsePlugin {
 
   override def spec: Spec = AMF
 
   override def applies(element: Root): Boolean = element.parsed match {
     case parsed: SyamlParsedDocument =>
-      FlattenedUnitGraphParser.canParse(parsed) || EmbeddedGraphParser.canParse(parsed)
+      FlattenedUnitGraphParser.canParse(parsed, aliases) || EmbeddedGraphParser.canParse(parsed)
     case _ => false
   }
 
@@ -30,7 +30,7 @@ object AMFGraphParsePlugin extends AMFParsePlugin {
 
   override def parse(document: Root, ctx: ParserContext): BaseUnit = document.parsed match {
     case parsed: SyamlParsedDocument if FlattenedUnitGraphParser.canParse(parsed) =>
-      FlattenedUnitGraphParser(ctx.config)
+      FlattenedUnitGraphParser(ctx.config, aliases)
         .parse(parsed.document, effectiveUnitUrl(document.location, ctx.parsingOptions))
     case parsed: SyamlParsedDocument if EmbeddedGraphParser.canParse(parsed) =>
       EmbeddedGraphParser(ctx.config).parse(parsed.document, effectiveUnitUrl(document.location, ctx.parsingOptions))

--- a/shared/src/test/resources/parser/unexpected-context.flattened.jsonld
+++ b/shared/src/test/resources/parser/unexpected-context.flattened.jsonld
@@ -1,0 +1,72 @@
+{
+  "@graph": [
+    {
+      "@id": "./",
+      "doc:declares": [
+        {
+          "@id": "amf://id3"
+        }
+      ],
+      "@type": [
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "doc:encodes": {
+        "@id": "amf://id2"
+      },
+      "doc:version": "1.0.0",
+      "doc:root": true
+    },
+    {
+      "@id": "amf://id3",
+      "@type": [
+        "data:Array",
+        "rdf:Seq",
+        "data:Node",
+        "doc:DomainElement"
+      ],
+      "rdf:member": [
+        {
+          "@id": "amf://id4"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id4",
+      "@type": [
+        "data:Scalar",
+        "data:Node",
+        "doc:DomainElement"
+      ],
+      "data:value": "myValue2",
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#String"
+        }
+      ]
+    },
+    {
+      "@id": "amf://id2",
+      "@type": [
+        "data:Scalar",
+        "data:Node",
+        "doc:DomainElement"
+      ],
+      "data:value": "myValue",
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#String"
+        }
+      ]
+    }
+  ],
+  "@context": {
+    "@base": "amf://id1",
+    "shacl": "http://www.w3.org/ns/shacl#",
+    "data": "http://a.ml/vocabularies/not-data#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/shared/src/test/scala/amf/core/parser/JsonLdContextOverrideTest.scala
+++ b/shared/src/test/scala/amf/core/parser/JsonLdContextOverrideTest.scala
@@ -1,0 +1,28 @@
+package amf.core.parser
+
+import amf.core.client.scala.AMFGraphConfiguration
+import amf.core.internal.plugins.parse.AMFGraphParsePlugin
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.ExecutionContext
+
+class JsonLdContextOverrideTest extends AsyncFunSuite with Matchers {
+
+  override implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  test("JSON-LD @context can be overriden by stepping on or adding new aliases") {
+    val aliases     = Map("doc" -> "http://a.ml/vocabularies/document#", "data" -> "http://a.ml/vocabularies/data#")
+    val plugin      = AMFGraphParsePlugin(aliases)
+    val errorClient = AMFGraphConfiguration.predefined().baseUnitClient()
+    val validClient = AMFGraphConfiguration.predefined().withPlugin(plugin).baseUnitClient()
+    val jsonld      = "file://shared/src/test/resources/parser/unexpected-context.flattened.jsonld"
+    for {
+      errorResult <- errorClient.parse(jsonld)
+      _           <- errorResult.conforms shouldBe false
+      validResult <- validClient.parse(jsonld)
+    } yield {
+      validResult.conforms shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
Shortcomings: @context override cannot be used for parse plugin applies. We could add the ParsingOptions to it but it seems weird. The other option is to add it as constructor param of the AMFGraphParsePlugin﻿
