### PR TITLE
Remove allowCycleClasses from ShapeTraversalRegistry

### DIFF
--- a/shared/src/main/scala/amf/core/client/scala/traversal/ShapeTraversalRegistry.scala
+++ b/shared/src/main/scala/amf/core/client/scala/traversal/ShapeTraversalRegistry.scala
@@ -9,15 +9,6 @@ case class ShapeTraversalRegistry() extends ModelTraversalRegistry() {
 
   def isAllowListed(id: String): Boolean = allowList.contains(id)
 
-  private var allowedCycleClasses: Seq[Class[_]] = Seq()
-
-  def withAllowedCyclesInstances(classes: Seq[Class[_]]): this.type = {
-    allowedCycleClasses = classes
-    this
-  }
-
-  def isAllowedToCycle(shape: Shape): Boolean = allowedCycleClasses.contains(shape.getClass)
-
   def allow(shapeIds: Set[String])(fnc: () => Shape): Shape = {
     val previousAllowList = allowList
     allowList = allowList ++ shapeIds
@@ -27,11 +18,8 @@ case class ShapeTraversalRegistry() extends ModelTraversalRegistry() {
   }
 
   def foundRecursion(root: Shape, current: Shape): Boolean = root.annotations.find(classOf[TypeAlias]) match {
-    case Some(alias) =>
-      val a = alias.aliasId.equals(current.id) && currentPath.nonEmpty || isInCurrentPath(current.id)
-      val b = !isAllowedToCycle(current)
-      a && b
-    case None => isInCurrentPath(current.id) && !isAllowedToCycle(current)
+    case Some(alias) => alias.aliasId.equals(current.id) && currentPath.nonEmpty || isInCurrentPath(current.id)
+    case None        => isInCurrentPath(current.id)
   }
 
 }


### PR DESCRIPTION
The motivation for allowCycleClasses is unclear. We don't know what cases are addressed by this logic:
 * The necessity for this logic is not explicit in the code 
 * Removing it does not break any tests
 * Its origin is opaque in Git history (first edit dates back to June 2018 with a big refactor)
 * Running all major API sets without it produce no regressions

Removing this to improve maintainability
