### PR TITLE
JSON-LD Schema PoC

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val workspaceDirectory: File =
     case _       => Path.userHome / "mulesoft"
   }
 
-val syamlVersion = "1.1.319"
+val syamlVersion = "1.1.320"
 
 lazy val syamlJVMRef = ProjectRef(workspaceDirectory / "syaml", "syamlJVM")
 lazy val syamlJSRef  = ProjectRef(workspaceDirectory / "syaml", "syamlJS")

--- a/shared/src/main/scala/amf/core/client/scala/AMFGraphConfiguration.scala
+++ b/shared/src/main/scala/amf/core/client/scala/AMFGraphConfiguration.scala
@@ -173,7 +173,7 @@ class AMFGraphConfiguration private[amf] (
 
   private[amf] def emptyEntities(): AMFGraphConfiguration   = super._emptyEntities()
   private[amf] def getParsingOptions: ParsingOptions        = options.parsingOptions
-  private[amf] def getRegistry: AMFRegistry                 = registry
+  def getRegistry: AMFRegistry                              = registry
   private[amf] def getResourceLoaders: List[ResourceLoader] = resolvers.resourceLoaders
   private[amf] def getUnitsCache: Option[UnitCache]         = resolvers.unitCache
   private[amf] def getExecutionContext: ExecutionContext    = resolvers.executionEnv.context

--- a/shared/src/main/scala/amf/core/client/scala/model/document/BaseUnitProcessingData.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/document/BaseUnitProcessingData.scala
@@ -10,7 +10,7 @@ import amf.core.internal.remote.Spec
 class BaseUnitProcessingData(val fields: Fields, val annotations: Annotations) extends AmfObject {
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override private[amf] def componentId = "/BaseUnitProcessingData"
+  override def componentId = "/BaseUnitProcessingData"
 
   def transformed: BoolField = fields.field(Transformed)
 

--- a/shared/src/main/scala/amf/core/client/scala/model/document/BaseUnitSourceInformation.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/document/BaseUnitSourceInformation.scala
@@ -11,7 +11,7 @@ import amf.core.internal.parser.domain.{Annotations, Fields}
 class BaseUnitSourceInformation(val fields: Fields, val annotations: Annotations) extends AmfObject {
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override private[amf] def componentId = "/BaseUnitSourceInformation"
+  override def componentId = "/BaseUnitSourceInformation"
 
   def rootLocation: StrField                     = fields.field(RootLocation)
   def withRootLocation(value: String): this.type = set(RootLocation, value)
@@ -33,7 +33,7 @@ object BaseUnitSourceInformation {
 class LocationInformation(val fields: Fields, val annotations: Annotations) extends AmfObject {
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  override private[amf] def componentId = "/LocationInformation"
+  override def componentId = "/LocationInformation"
 
   def locationValue: StrField                = fields.field(BaseUnitModel.Location)
   def withLocation(value: String): this.type = set(BaseUnitModel.Location, value)

--- a/shared/src/main/scala/amf/core/client/scala/model/document/Document.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/document/Document.scala
@@ -22,7 +22,7 @@ case class Document(fields: Fields, annotations: Annotations) extends BaseUnit w
   override def meta: DocumentModel = DocumentModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String = ""
+  override def componentId: String = ""
 }
 
 object Document {

--- a/shared/src/main/scala/amf/core/client/scala/model/document/Fragment.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/document/Fragment.scala
@@ -15,7 +15,7 @@ trait Fragment extends BaseUnit with EncodesModel {
   override def meta: FragmentModel = FragmentModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String = ""
+  override def componentId: String = ""
 
 }
 

--- a/shared/src/main/scala/amf/core/client/scala/model/document/Module.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/document/Module.scala
@@ -28,7 +28,7 @@ case class Module(fields: Fields, annotations: Annotations)
   override def meta: ModuleModel = ModuleModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String = ""
+  override def componentId: String = ""
 
   def customDomainProperties: Seq[DomainExtension] = fields.field(CustomDomainProperties)
 

--- a/shared/src/main/scala/amf/core/client/scala/model/document/RecursiveUnit.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/document/RecursiveUnit.scala
@@ -17,7 +17,7 @@ case class RecursiveUnit(fields: Fields, annotations: Annotations) extends Fragm
     override def modelInstance: AmfObject = RecursiveUnit()
   }
 
-  private[amf] override def componentId: String = "/recursive"
+  override def componentId: String = "/recursive"
 }
 
 object RecursiveUnit {

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/AmfObject.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/AmfObject.scala
@@ -34,7 +34,7 @@ trait AmfObject extends AmfElement {
   }
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] def componentId: String
+  def componentId: String
 
   /** Call after object has been adopted by specified parent. */
   final def simpleAdoption(parent: String): this.type = {

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/DataNode.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/DataNode.scala
@@ -9,7 +9,10 @@ import amf.core.internal.utils.AmfStrings
 
 /** Base class for all dynamic DataNodes
   */
-abstract class DataNode(annotations: Annotations) extends DomainElement with NamedDomainElement with HasShapeFederationMetadata {
+abstract class DataNode(annotations: Annotations)
+    extends DomainElement
+    with NamedDomainElement
+    with HasShapeFederationMetadata {
 
   override protected def nameField: Field = DataNodeModel.Name // ??
 
@@ -17,7 +20,7 @@ abstract class DataNode(annotations: Annotations) extends DomainElement with Nam
     if (Option(id).isEmpty) simpleAdoption(parent) else this
   }
 
-  private[amf] override def componentId: String =
+  override def componentId: String =
     "/" + name.option().getOrElse("data-node").urlComponentEncoded
 
   /** Replace all raml variables (any name inside double chevrons -> '<<>>') with the provided values. */

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/ExternalDomainElement.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/ExternalDomainElement.scala
@@ -21,7 +21,7 @@ case class ExternalDomainElement(fields: Fields, annotations: Annotations) exten
   var parsed: Option[YNode] = None
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String = "/external"
+  override def componentId: String = "/external"
 }
 
 object ExternalDomainElement {

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/RecursiveShape.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/RecursiveShape.scala
@@ -40,7 +40,7 @@ class RecursiveShape(override val fields: Fields, override val annotations: Anno
   override def meta: RecursiveShapeModel.type = RecursiveShapeModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String =
+  override def componentId: String =
     name.option().map(name => s"/${name.urlComponentEncoded}").getOrElse("") + "/recursive"
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/Shape.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/Shape.scala
@@ -7,6 +7,7 @@ import amf.core.client.scala.model.{BoolField, StrField}
 import amf.core.client.scala.traversal.ShapeTraversalRegistry
 import amf.core.internal.annotations.LexicalInformation
 import amf.core.internal.metamodel.Field
+import amf.core.internal.metamodel.domain.ShapeModel
 import amf.core.internal.metamodel.domain.ShapeModel._
 import amf.core.internal.parser.domain.Annotations
 import amf.core.internal.plugins.domain.shapes.models.ShapeHelper
@@ -160,16 +161,16 @@ abstract class Shape
         case s: Shape if s.id == this.id => s
         case a: AmfArray =>
           AmfArray(
-            a.values.map {
-              case e: Shape if e.id != this.id =>
-                traversal.runNested((t: ShapeTraversalRegistry) => {
-                  e.cloneShape(recursionErrorHandler, recursionBase, t)
-                })
+              a.values.map {
+                case e: Shape if e.id != this.id =>
+                  traversal.runNested((t: ShapeTraversalRegistry) => {
+                    e.cloneShape(recursionErrorHandler, recursionBase, t)
+                  })
 //                e.cloneShape(recursionErrorHandler, recursionBase, traversed.push(prevBaseId),Some(prevBaseId))
-              case e: Shape if e.id == this.id => e
-              case o                           => o
-            },
-            a.annotations
+                case e: Shape if e.id == this.id => e
+                case o                           => o
+              },
+              a.annotations
           )
         case o => o
       }
@@ -186,4 +187,17 @@ abstract class Shape
     val copiedShape = copyElement(a).asInstanceOf[this.type]
     copiedShape
   }
+
+  protected[amf] def isXOne: Boolean = fields.exists(ShapeModel.Xone) && xone.nonEmpty
+
+  protected[amf] def isOr: Boolean = fields.exists(ShapeModel.Or) && or.nonEmpty
+
+  protected[amf] def isAnd: Boolean = fields.exists(ShapeModel.And) && and.nonEmpty
+
+  protected[amf] def isNot: Boolean = fields.exists(ShapeModel.Not)
+
+  protected[amf] def isConditional: Boolean =
+    fields.exists(ShapeModel.If) ||
+      fields.exists(ShapeModel.Else) ||
+      fields.exists(ShapeModel.Then)
 }

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/context/EntityContext.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/context/EntityContext.scala
@@ -1,0 +1,35 @@
+package amf.core.client.scala.model.domain.context
+
+import amf.core.client.scala.model.document.BaseUnit
+import amf.core.client.scala.vocabulary.ValueType
+import amf.core.internal.metamodel.Field
+import amf.core.internal.metamodel.domain.DomainElementModel
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+class EntityContext(val entities: List[EntityModel]) {}
+
+case class EntityModel(`type`: ValueType, properties: Map[ValueType, ValueType])
+
+class EntityContextBuilder() {
+  def build(): EntityContext = new EntityContext(
+      entities
+        .map({ case (uri, list) => EntityModel(uri, list.map(f => f.value -> f.`type`.`type`.head).toMap) })
+        .toList
+  )
+
+  val entities: mutable.Map[ValueType, Set[Field]] = mutable.Map()
+
+  def +(jsonLDElementModel: DomainElementModel): EntityContextBuilder = {
+    entities.get(jsonLDElementModel.`type`.head) match {
+      case Some(l) => entities.update(jsonLDElementModel.`type`.head, jsonLDElementModel.fields.toSet ++ l)
+      case _       => entities.put(jsonLDElementModel.`type`.head, jsonLDElementModel.fields.toSet)
+    }
+    this
+  }
+}
+
+trait SelfContainedContext {
+  val entityContext: EntityContext
+}

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/extensions/CustomDomainProperty.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/extensions/CustomDomainProperty.scala
@@ -42,7 +42,7 @@ case class CustomDomainProperty(fields: Fields, annotations: Annotations)
   override def meta = CustomDomainPropertyModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String = name.option().map(_.urlComponentEncoded).getOrElse("")
+  override def componentId: String = name.option().map(_.urlComponentEncoded).getOrElse("")
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */
   override protected def classConstructor: (Fields, Annotations) => Linkable with DomainElement =

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/extensions/DomainExtension.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/extensions/DomainExtension.scala
@@ -27,7 +27,7 @@ case class DomainExtension(fields: Fields, annotations: Annotations) extends Ext
   // for the extension point. ID is not required for serialisation
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String = customDomainPropertyName.getOrElse("/extension")
+  override def componentId: String = customDomainPropertyName.getOrElse("/extension")
 
   private def customDomainPropertyName: Option[String] = Option(definedBy).flatMap(_.name.option()).map(x => s"/$x")
 

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/extensions/PropertyShape.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/extensions/PropertyShape.scala
@@ -11,8 +11,7 @@ import amf.core.internal.utils.AmfStrings
 
 /** Property shape
   */
-case class PropertyShape(fields: Fields, annotations: Annotations)
-    extends Shape {
+case class PropertyShape(fields: Fields, annotations: Annotations) extends Shape {
 
   def path: StrField                   = fields.field(Path)
   def range: Shape                     = fields.field(Range)
@@ -56,7 +55,7 @@ case class PropertyShape(fields: Fields, annotations: Annotations)
   }
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String =
+  override def componentId: String =
     "/property/" + name.option().getOrElse("default-property").urlComponentEncoded
 
   /** apply method for create a new instance with fields and annotations. Aux method for copy */

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/extensions/PropertyShapePath.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/extensions/PropertyShapePath.scala
@@ -16,7 +16,7 @@ case class PropertyShapePath private[amf] (override val fields: Fields, override
 
   override val meta: PropertyShapePathModel.type = PropertyShapePathModel
 
-  private[amf] override def componentId: String = "/property-shape-path"
+  override def componentId: String = "/property-shape-path"
 
 }
 

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/extensions/ShapeExtension.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/extensions/ShapeExtension.scala
@@ -26,7 +26,7 @@ case class ShapeExtension(fields: Fields, annotations: Annotations) extends Exte
   // for the extension point. ID is not required for serialisation
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String =
+  override def componentId: String =
     "/shape-extension/" +
       Option(definedBy).flatMap(_.name.option()).getOrElse("default-extension").urlComponentEncoded
 }

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/federation/ShapeFederationMetadata.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/federation/ShapeFederationMetadata.scala
@@ -6,7 +6,7 @@ import org.yaml.model.YMap
 
 case class ShapeFederationMetadata(fields: Fields, annotations: Annotations) extends FederationMetadata {
   override def meta: ShapeFederationMetadataModel.type = ShapeFederationMetadataModel
-  override private[amf] def componentId                = s"/federation-metadata"
+  override def componentId                             = s"/federation-metadata"
 }
 
 object ShapeFederationMetadata {

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/templates/AbstractDeclaration.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/templates/AbstractDeclaration.scala
@@ -22,7 +22,7 @@ abstract class AbstractDeclaration(fields: Fields, annotations: Annotations)
   def withDescription(description: String): this.type  = set(Description, description)
 
   protected def declarationComponent: String
-  private[amf] override def componentId: String =
+  override def componentId: String =
     "/" + declarationComponent + "/" + name.option().getOrElse("default-abstract").urlComponentEncoded
   override def nameField: Field = Name
 }

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/templates/ParametrizedDeclaration.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/templates/ParametrizedDeclaration.scala
@@ -18,7 +18,7 @@ abstract class ParametrizedDeclaration(fields: Fields, annotations: Annotations)
   /** Set variables property. */
   def withVariables(variables: Seq[VariableValue]): this.type = setArray(Variables, variables)
 
-  private[amf] override def componentId: String =
+  override def componentId: String =
     "/" + name.option().getOrElse("default-parametrized").urlComponentEncoded
 
   override def nameField: Field = Name

--- a/shared/src/main/scala/amf/core/client/scala/model/domain/templates/VariableValue.scala
+++ b/shared/src/main/scala/amf/core/client/scala/model/domain/templates/VariableValue.scala
@@ -20,7 +20,7 @@ case class VariableValue(fields: Fields, annotations: Annotations) extends Domai
   override def meta: VariableValueModel.type = VariableValueModel
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String = "/" + name.option().getOrElse("default-variable").urlComponentEncoded
+  override def componentId: String = "/" + name.option().getOrElse("default-variable").urlComponentEncoded
 
   override protected def nameField: Field = Name
 }

--- a/shared/src/main/scala/amf/core/client/scala/parse/document/ParserContext.scala
+++ b/shared/src/main/scala/amf/core/client/scala/parse/document/ParserContext.scala
@@ -9,6 +9,7 @@ import amf.core.internal.parser.ParseConfiguration
 import amf.core.internal.parser.domain.FutureDeclarations
 import amf.core.internal.plugins.syntax.SYamlBasedErrorHandler
 import amf.core.internal.validation.core.ValidationSpecification
+import org.mulesoft.common.client.lexical.SourceLocation
 
 import scala.collection.mutable
 
@@ -27,6 +28,8 @@ trait ErrorHandlingContext {
   def violation(violationId: ValidationSpecification, node: String, message: String)
 
   def violation(violationId: ValidationSpecification, node: AmfObject, message: String)
+
+  def violation(specification: ValidationSpecification, node: String, message: String, loc: SourceLocation): Unit
 }
 
 trait UnresolvedComponents {

--- a/shared/src/main/scala/amf/core/client/scala/parse/document/ParserContext.scala
+++ b/shared/src/main/scala/amf/core/client/scala/parse/document/ParserContext.scala
@@ -86,4 +86,10 @@ case class ParserContext(
 
   def parsingOptions: ParsingOptions = config.parsingOptions
 
+  override def violation(
+      specification: ValidationSpecification,
+      node: String,
+      message: String,
+      loc: SourceLocation
+  ): Unit = eh.violation(specification, node, message, loc)
 }

--- a/shared/src/main/scala/amf/core/internal/metamodel/Type.scala
+++ b/shared/src/main/scala/amf/core/internal/metamodel/Type.scala
@@ -54,6 +54,7 @@ object Type {
 
   object Bool extends Scalar("boolean")
 
+  object Null extends Scalar("null")
   object ObjType extends Obj {
     override val fields: List[Field]     = Nil
     override val `type`: List[ValueType] = Nil

--- a/shared/src/main/scala/amf/core/internal/parser/AMFGraphPartialCompiler.scala
+++ b/shared/src/main/scala/amf/core/internal/parser/AMFGraphPartialCompiler.scala
@@ -32,7 +32,7 @@ class AMFGraphPartialCompiler(compilerContext: CompilerContext, startingPoint: S
       override val fields: Fields = Fields()
 
       /** Value , path + field value that is used to compose the id when the object its adopted */
-      private[amf] override def componentId: String = "error"
+      override def componentId: String = "error"
 
       /** Set of annotations for element. */
       override val annotations: Annotations = Annotations()
@@ -97,5 +97,5 @@ private[amf] case class AmfObjectUnitContainer(
   override def references: Seq[BaseUnit] = Nil
 
   /** Value , path + field value that is used to compose the id when the object its adopted */
-  private[amf] override def componentId: String = ""
+  override def componentId: String = ""
 }

--- a/shared/src/main/scala/amf/core/internal/plugins/document/graph/JsonLdKeywords.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/document/graph/JsonLdKeywords.scala
@@ -1,11 +1,12 @@
 package amf.core.internal.plugins.document.graph
 
 object JsonLdKeywords {
-  val Base    = "@base"
-  val Context = "@context"
-  val Id      = "@id"
-  val Value   = "@value"
-  val Graph   = "@graph"
-  val Type    = "@type"
-  val List    = "@list"
+  val Base     = "@base"
+  val Context  = "@context"
+  val Id       = "@id"
+  val Value    = "@value"
+  val Graph    = "@graph"
+  val Type     = "@type"
+  val List     = "@list"
+  val Entities = "@entities"
 }

--- a/shared/src/main/scala/amf/core/internal/plugins/document/graph/emitter/CommonEmitter.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/document/graph/emitter/CommonEmitter.scala
@@ -27,7 +27,7 @@ import amf.core.internal.parser.domain.{Annotations, FieldEntry, Value}
 import amf.core.internal.plugins.document.graph.JsonLdKeywords
 import amf.core.internal.plugins.document.graph.emitter.utils.{ScalarEmitter, SourceMapEmitter, SourceMapsAllowList}
 import org.mulesoft.common.time.SimpleDateTime
-import org.yaml.builder.DocBuilder.{Entry, Part, SType}
+import org.yaml.builder.DocBuilder.{Entry, Part, SType, Scalar}
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -384,6 +384,9 @@ abstract class CommonEmitter[T, C <: GraphEmitterContext](options: RenderOptions
       case Type.Date =>
         emitDate(v, b)
         sources(v)
+      case Type.Null =>
+        emitNull(b)
+        sources(v)
       case a: SortedArray =>
         createSortedArray(b, v.value.asInstanceOf[AmfArray].values, parent, a.element)
         sources(v)
@@ -400,6 +403,9 @@ abstract class CommonEmitter[T, C <: GraphEmitterContext](options: RenderOptions
     }
   }
 
+  protected def emitNull(b: Part[T]) = {
+    b += Scalar(SType.Null, null)
+  }
   protected def emitArray(a: Array, v: Value, b: Part[T], sources: Value => Unit) = {
     b.list { b =>
       val seq = v.value.asInstanceOf[AmfArray]

--- a/shared/src/main/scala/amf/core/internal/plugins/document/graph/emitter/GraphEmitterContext.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/document/graph/emitter/GraphEmitterContext.scala
@@ -2,9 +2,10 @@ package amf.core.internal.plugins.document.graph.emitter
 
 import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.model.document.{BaseUnit, Fragment, Module}
+import amf.core.client.scala.model.domain.context.{EntityContext, EntityModel, SelfContainedContext}
 import amf.core.client.scala.model.domain.{AmfElement, DomainElement}
 import amf.core.internal.utils.IdCounter
-import amf.core.client.scala.vocabulary.{Namespace, NamespaceAliases}
+import amf.core.client.scala.vocabulary.{Namespace, NamespaceAliases, ValueType}
 import amf.core.internal.plugins.document.graph.JsonLdKeywords
 import org.yaml.builder.DocBuilder.Entry
 

--- a/shared/src/main/scala/amf/core/internal/plugins/document/graph/parser/GraphParserContext.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/document/graph/parser/GraphParserContext.scala
@@ -10,6 +10,7 @@ import amf.core.internal.parser.ParseConfiguration
 import amf.core.internal.parser.domain.FutureDeclarations
 import amf.core.internal.plugins.document.graph.context.GraphContext
 import amf.core.internal.plugins.syntax.{SYamlAMFParserErrorHandler, SyamlAMFErrorHandler}
+import amf.core.internal.validation.core.ValidationSpecification
 import org.mulesoft.common.client.lexical.SourceLocation
 import org.yaml.model.{IllegalTypeHandler, ParseErrorHandler, SyamlException, YError}
 
@@ -27,4 +28,11 @@ class GraphParserContext(
     }
     this
   }
+
+  override def violation(
+      specification: ValidationSpecification,
+      node: String,
+      message: String,
+      loc: SourceLocation
+  ): Unit = eh.violation(specification, node, message, loc)
 }

--- a/shared/src/main/scala/amf/core/internal/plugins/render/AMFGraphRenderPlugin.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/render/AMFGraphRenderPlugin.scala
@@ -1,9 +1,11 @@
 package amf.core.internal.plugins.render
 
 import amf.core.client.common.{LowPriority, PluginPriority}
+import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.vocabulary.{Namespace, NamespaceAliases}
 import amf.core.internal.plugins.document.graph.emitter.{
+  ApplicableMetaFieldRenderProvider,
   EmbeddedJsonLdEmitter,
   FlattenedJsonLdEmitter,
   SemanticExtensionAwareFieldRenderProvision,
@@ -15,7 +17,8 @@ import amf.core.internal.remote.Amf
 import amf.core.internal.remote.Mimes._
 import org.yaml.builder.DocBuilder
 
-object AMFGraphRenderPlugin extends AMFRenderPlugin {
+object AMFGraphRenderPlugin extends AMFGraphRenderPlugin
+trait AMFGraphRenderPlugin extends AMFRenderPlugin {
 
   override val id: String = Amf.id
 
@@ -34,6 +37,9 @@ object AMFGraphRenderPlugin extends AMFRenderPlugin {
     }
   }
 
+  def flattenEmissionFN[T]
+      : (BaseUnit, DocBuilder[T], RenderOptions, NamespaceAliases, ApplicableMetaFieldRenderProvider) => Boolean =
+    FlattenedJsonLdEmitter.emit
   def emitToYDocBuilder[T](unit: BaseUnit, builder: DocBuilder[T], renderConfig: RenderConfiguration): Boolean = {
     val options          = renderConfig.renderOptions
     val namespaceAliases = renderConfig.namespaceAliases
@@ -41,7 +47,7 @@ object AMFGraphRenderPlugin extends AMFRenderPlugin {
       case JsonLdSerialization(EmbeddedForm) => EmbeddedJsonLdEmitter.emit(unit, builder, options, namespaceAliases)
       // defaults to flatten
       case _ =>
-        FlattenedJsonLdEmitter.emit(
+        flattenEmissionFN(
             unit,
             builder,
             options,

--- a/shared/src/main/scala/amf/core/internal/plugins/syntax/SyamlSyntaxRenderPlugin.scala
+++ b/shared/src/main/scala/amf/core/internal/plugins/syntax/SyamlSyntaxRenderPlugin.scala
@@ -41,7 +41,8 @@ object SyamlSyntaxRenderPlugin extends AMFSyntaxRenderPlugin with PlatformSecret
         `text/x-yaml`,
         `application/json`,
         `text/json`,
-        `text/vnd.yaml`
+        `text/vnd.yaml`,
+        "application/schemald+json"
     )
 
   override val id: String = "syaml-render"

--- a/shared/src/main/scala/amf/core/internal/remote/Mimes.scala
+++ b/shared/src/main/scala/amf/core/internal/remote/Mimes.scala
@@ -21,9 +21,9 @@ object Mimes {
   val `application/protobuf`: String              = "application/protobuf"
   val `application/grpc`: String                  = "application/grpc"
   val `application/semantics+schema+json`: String = "application/semantics+schema+json"
-
-  val `application/protobuf_` : String = "application/protobuf; proto=org.some.Message"
-  val `application/vnd_google`: String = "application/vnd.google.protobuf"
-  val `application/graphql`: String    = "application/graphql"
+  val `application/schema+ld+json`: String        = "application/schema+ld+json"
+  val `application/protobuf_` : String            = "application/protobuf; proto=org.some.Message"
+  val `application/vnd_google`: String            = "application/vnd.google.protobuf"
+  val `application/graphql`: String               = "application/graphql"
 
 }

--- a/shared/src/main/scala/amf/core/internal/remote/Spec.scala
+++ b/shared/src/main/scala/amf/core/internal/remote/Spec.scala
@@ -21,6 +21,7 @@ object Spec {
       case GraphQL.id           => Some(GraphQL)
       case GraphQLFederation.id => Some(GraphQLFederation)
       case JsonSchemaDialect.id => Some(JsonSchemaDialect)
+      case JsonLDSchema.id      => Some(JsonLDSchema)
       case _                    => None
     }
   }
@@ -44,6 +45,7 @@ object Spec {
   @JSExport val GRAPHQL: Spec            = GraphQL
   @JSExport val GRAPHQL_FEDERATION: Spec = GraphQLFederation
   @JSExport val JSONSCHEMADIALECT: Spec  = JsonSchemaDialect
+  @JSExport val JSONDLSCHEMA: Spec       = JsonLDSchema
 }
 
 @JSExportAll
@@ -179,4 +181,9 @@ private[amf] case object GraphQLFederation extends Spec {
 private[amf] case object JsonSchemaDialect extends Spec {
   override val id: String        = "JSON Schema Dialect"
   override val mediaType: String = `application/semantics+schema+json`
+}
+
+private[amf] case object JsonLDSchema extends Spec {
+  override val id: String        = "JSONLD Schema"
+  override val mediaType: String = `application/schema+ld+json`
 }

--- a/shared/src/test/scala/amf/core/client/common/parser/InternalSeqAtGraphParserTest.scala
+++ b/shared/src/test/scala/amf/core/client/common/parser/InternalSeqAtGraphParserTest.scala
@@ -37,7 +37,7 @@ class InternalSeqAtGraphParserTest()
         override val fields: Fields = Fields()
 
         /** Value , path + field value that is used to compose the id when the object its adopted */
-        override private[amf] def componentId = "fake"
+        override def componentId = "fake"
 
         /** Set of annotations for element. */
         override val annotations: Annotations = Annotations()

--- a/shared/src/test/scala/amf/core/client/scala/model/ModelCloneTest.scala
+++ b/shared/src/test/scala/amf/core/client/scala/model/ModelCloneTest.scala
@@ -101,8 +101,8 @@ class ModelCloneTest extends AnyFunSuite with ElementsFixture with Matchers {
         override val `type`: List[ValueType]  = Nil
         override def modelInstance: AmfObject = SomeType(Fields(), Annotations())
       }
-      private[amf] override def componentId: String = "someId"
-      override def hashCode(): Int                  = 1
+      override def componentId: String = "someId"
+      override def hashCode(): Int     = 1
     }
 
     val type1 = SomeType(Fields(), Annotations())
@@ -127,8 +127,8 @@ class ModelCloneTest extends AnyFunSuite with ElementsFixture with Matchers {
 
   test("test clone id for error declaration") {
     case class Dummy(fields: Fields = Fields(), annotations: Annotations = Annotations()) extends DomainElement {
-      override def meta: DummyModel.type            = DummyModel
-      private[amf] override def componentId: String = ""
+      override def meta: DummyModel.type = DummyModel
+      override def componentId: String   = ""
     }
 
     object DummyModel extends DomainElementModel {
@@ -148,7 +148,7 @@ class ModelCloneTest extends AnyFunSuite with ElementsFixture with Matchers {
       override val fields: Fields = Fields()
 
       /** Value , path + field value that is used to compose the id when the object its adopted */
-      private[amf] override def componentId: String = "errorTrait"
+      override def componentId: String = "errorTrait"
 
       /** Set of annotations for element. */
       override val annotations: Annotations = Annotations()


### PR DESCRIPTION
- (jsonld-schema/0): Add jsonld schema spec and miime type. Move conditional methods from anyshape to shape
- (jsonld-schema/1): Remove entity emission from context
- (jsonld-schema/2): Extract some array emition logic to methods so can be overrided at jsonld schema plugin
- (jsonld-schema/3): Make componentId domain element method, public
- (jsonld-schema/4): Bump syaml version and emit Null scalars
- (jsonld-schema/5): fixed test
