### PR TITLE
#1626: Add render options to specify if implicitRamlTypes should be used while rendering.

### DIFF
--- a/shared/src/main/scala/amf/core/client/platform/config/RenderOptions.scala
+++ b/shared/src/main/scala/amf/core/client/platform/config/RenderOptions.scala
@@ -70,6 +70,9 @@ case class RenderOptions(private[amf] val _internal: InternalRenderOptions) {
   /** Include a reduced version of source maps when rendering to graph. */
   def withGovernanceMode: RenderOptions = _internal.withGovernanceMode
 
+  /** Always render `type` facade on types even if the type is already clear by a unique facade. */
+  def withoutImplicitRamlTypes(): RenderOptions = _internal.withoutImplicitRamlTypes
+
   def isWithDocumentation: Boolean     = _internal.isWithDocumentation
   def isWithCompactedEmission: Boolean = _internal.isWithCompactedEmission
   def schemaVersion: JSONSchemaVersion = _internal.schemaVersion

--- a/shared/src/main/scala/amf/core/client/scala/config/RenderOptions.scala
+++ b/shared/src/main/scala/amf/core/client/scala/config/RenderOptions.scala
@@ -23,7 +23,8 @@ case class RenderOptions(
     emitWarningForUnsupportedValidationFacets: Boolean = false,
     schema: JSONSchemaVersion = JSONSchemaVersions.Unspecified,
     rawFieldEmission: Boolean = false,
-    governanceMode: Boolean = false
+    governanceMode: Boolean = false,
+    implicitRamlTypes: Boolean = true
 ) {
 
   /** Include PrettyPrint when rendering to graph. */
@@ -108,6 +109,9 @@ case class RenderOptions(
 
   /** Include a reduced version of source maps when rendering to graph. */
   def withGovernanceMode: RenderOptions = copy(governanceMode = true)
+
+  /** Always render `type` facade on types even if the type is already clear by a unique facade. */
+  def withoutImplicitRamlTypes: RenderOptions = copy(implicitRamlTypes = true)
 
   def isWithDocumentation: Boolean                             = documentation
   def isWithCompactedEmission: Boolean                         = compactedEmission


### PR DESCRIPTION
Corresponding issue: https://github.com/aml-org/amf/issues/1626